### PR TITLE
Add support for C++20 coroutines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ INSTALL
 Makefile
 TAGS
 autom4te*
-m4
+m4/*.m4
+!/m4/m4_ax_cxx_compile_stdcxx.m4
 !external/libsodium/m4
 !external/secp256k1/build-aux/m4
 stamp-*

--- a/Boss/Mod/ChannelCandidateInvestigator/Manager.cpp
+++ b/Boss/Mod/ChannelCandidateInvestigator/Manager.cpp
@@ -212,7 +212,7 @@ void Manager::start() {
 		/* Human-readable text.  */
 		auto report = std::make_shared<std::string>();
 
-		return db.transact().then([=](Sqlite3::Tx tx) {
+		return db.transact().then([=, this](Sqlite3::Tx tx) {
 			auto act = Ev::lift();
 			/* First, if there are too many candidates,
 			 * delete one by random.
@@ -253,7 +253,7 @@ void Manager::start() {
 					);
 
 			return act;
-		}).then([=]() {
+		}).then([=, this]() {
 			/* If we are online, continue.  */
 			if (imon.is_online())
 				return Ev::lift();
@@ -264,7 +264,7 @@ void Manager::start() {
 					, "ChannelCandidateInvestigator: "
 					  "Offline.  Not investigating."
 					);
-		}).then([=]() {
+		}).then([=, this]() {
 			/* If too few candidates, get more.  */
 			if (*good_candidates < min_good_candidates)
 				return solicit_candidates(*good_candidates);
@@ -278,7 +278,7 @@ void Manager::start() {
 				return solicit_candidates(*good_candidates);
 
 			return Ev::lift();
-		}).then([=]() {
+		}).then([=, this]() {
 			/* Hand over possible cases to the gumshoe.  */
 			auto to_gumshoe = [this](Ln::NodeId n) {
 				return gumshoe.investigate(n).then([]() {

--- a/Boss/Mod/ChannelCreateDestroyMonitor.cpp
+++ b/Boss/Mod/ChannelCreateDestroyMonitor.cpp
@@ -204,7 +204,7 @@ void ChannelCreateDestroyMonitor::start() {
 		return destruction(bus, n);
 	};
 	bus.subscribe<Msg::Notification
-		     >([=](Msg::Notification const& n) {
+		     >([=, this](Msg::Notification const& n) {
 		if (n.notification == "channel_opened")
 			return on_channel_opened(n.params);
 		else if (n.notification == "channel_state_changed") {

--- a/Boss/Mod/FeeModderBySize.cpp
+++ b/Boss/Mod/FeeModderBySize.cpp
@@ -169,7 +169,7 @@ private:
 					);
 		}
 
-		return std::move(act).then([=]() {
+		return std::move(act).then([=, this]() {
 			auto channel = **pit;
 			++(*pit);
 			auto source = Ln::NodeId(std::string(

--- a/Boss/Mod/Rpc.cpp
+++ b/Boss/Mod/Rpc.cpp
@@ -347,9 +347,9 @@ public:
 	Ev::Io<Jsmn::Object> core_command( std::string const& command
 					 , Json::Out params
 					 ) {
-		return Ev::Io<Jsmn::Object>([=]( std::function<void(Jsmn::Object)> pass
-					       , std::function<void(std::exception_ptr)> fail
-					       ) {
+		return Ev::Io<Jsmn::Object>([=, this]( std::function<void(Jsmn::Object)> pass
+						     , std::function<void(std::exception_ptr)> fail
+						     ) {
 			if (is_shutting_down) {
 				try {
 					throw Boss::Shutdown();

--- a/Ev/coroutine.cpp
+++ b/Ev/coroutine.cpp
@@ -1,0 +1,61 @@
+#include"Ev/coroutine.hpp"
+#include<cassert>
+#include<ev.h>
+
+namespace {
+
+/* Take advantage of the fact that `Ev:::Io` is
+fully intended to be used only in the main thread.
+*/
+auto cleaning_list = (Ev::coroutine::ToBeCleaned*)(nullptr);
+
+/* To avoid allocating in schdule_for_cleaning, also
+statically-allocate the idler object.
+*/
+auto cleaning_idle = ev_idle();
+
+void cleaning_handler(EV_P_ ev_idle* raw_idler, int) {
+	assert(raw_idler == &cleaning_idle);
+	/* Tell libev to stop the idling.  */
+	ev_idle_stop(EV_A_ &cleaning_idle);
+	/* And clean it up, which should reset the
+	cleaning list to empty.
+	*/
+	Ev::coroutine::do_cleaning_as_scheduled();
+}
+
+}
+
+namespace Ev::coroutine {
+
+void schedule_for_cleaning(ToBeCleaned* obj) noexcept {
+	auto need_to_schedule = (cleaning_list == nullptr);
+	obj->next = cleaning_list;
+	cleaning_list = obj;
+	if (!need_to_schedule) {
+		return;
+	}
+	/* Should not fail.  Dunno if libev has to allocate
+	here but at least these are C libraries and should
+	not *throw* at least (^^;).
+	*/
+	ev_idle_init(&cleaning_idle, &cleaning_handler);
+	ev_idle_start(EV_DEFAULT_ &cleaning_idle);
+}
+
+void do_cleaning_as_scheduled() {
+	while (cleaning_list) {
+		auto head = cleaning_list;
+		auto next = head->next;
+		head->next = nullptr;
+		cleaning_list = next;
+		/* Make a best-effort at cleaning this up.  */
+		try {
+			head->clean();
+		} catch (...) { }
+	}
+}
+
+
+}
+

--- a/Ev/coroutine.cpp
+++ b/Ev/coroutine.cpp
@@ -4,7 +4,7 @@
 
 namespace {
 
-/* Take advantage of the fact that `Ev:::Io` is
+/* Take advantage of the fact that `Ev::Io` is
 fully intended to be used only in the main thread.
 */
 auto cleaning_list = (Ev::coroutine::ToBeCleaned*)(nullptr);

--- a/Ev/coroutine.cpp
+++ b/Ev/coroutine.cpp
@@ -9,7 +9,7 @@ fully intended to be used only in the main thread.
 */
 auto cleaning_list = (Ev::coroutine::ToBeCleaned*)(nullptr);
 
-/* To avoid allocating in schdule_for_cleaning, also
+/* To avoid allocating in schedule_for_cleaning, also
 statically-allocate the idler object.
 */
 auto cleaning_idle = ev_idle();

--- a/Ev/coroutine.cpp
+++ b/Ev/coroutine.cpp
@@ -1,5 +1,9 @@
 #include"Ev/coroutine.hpp"
 #include<cassert>
+#include<cstdio>
+#include<cstdlib>
+#include<functional>
+#include<thread>
 #include<ev.h>
 
 namespace {
@@ -28,7 +32,35 @@ void cleaning_handler(EV_P_ ev_idle* raw_idler, int) {
 
 namespace Ev::coroutine {
 
+#ifndef NDEBUG
+namespace detail {
+
+auto const main_thread_id = std::this_thread::get_id();
+
+[[noreturn]]
+void assert_fail_off_main_thread(char const* where) noexcept {
+	auto const main_tid = std::hash<std::thread::id>()(main_thread_id);
+	auto const curr_tid = std::hash<std::thread::id>()(std::this_thread::get_id());
+	std::fprintf(stderr,
+		     "%s called off main thread (main tid hash=%zu, current tid hash=%zu).\n"
+		     "This is unsafe: it mutates coroutine cleanup state and uses libev watchers without synchronization.\n",
+		     where, main_tid, curr_tid);
+	std::abort();
+}
+
+void assert_main_thread(char const* where) noexcept {
+	if (std::this_thread::get_id() != main_thread_id) {
+		assert_fail_off_main_thread(where);
+	}
+}
+
+}
+#endif
+
 void schedule_for_cleaning(ToBeCleaned* obj) noexcept {
+#ifndef NDEBUG
+	detail::assert_main_thread("Ev::coroutine::schedule_for_cleaning");
+#endif
 	auto need_to_schedule = (cleaning_list == nullptr);
 	obj->next = cleaning_list;
 	cleaning_list = obj;
@@ -58,4 +90,3 @@ void do_cleaning_as_scheduled() noexcept {
 
 
 }
-

--- a/Ev/coroutine.cpp
+++ b/Ev/coroutine.cpp
@@ -43,7 +43,7 @@ void schedule_for_cleaning(ToBeCleaned* obj) noexcept {
 	ev_idle_start(EV_DEFAULT_ &cleaning_idle);
 }
 
-void do_cleaning_as_scheduled() {
+void do_cleaning_as_scheduled() noexcept {
 	while (cleaning_list) {
 		auto head = cleaning_list;
 		auto next = head->next;

--- a/Ev/coroutine.hpp
+++ b/Ev/coroutine.hpp
@@ -1,0 +1,396 @@
+#ifndef EV_COROUTINE_HPP
+#define EV_COROUTINE_HPP
+
+#include"Ev/Io.hpp"
+#include<coroutine>
+#include<utility>
+
+/** Contains support for using `Ev::Io` in C++20
+ * coroutines, allowing for convenient syntax
+ * without the burden of `.then()`.
+ *
+ * The contents of this namespace are not supposed
+ * to be *explicitly* used by coroutine code; just
+ * include this header file and write coroutines
+ * directly with `co_await` and `co_return`, and the
+ * compiler will instantiate the necessary classes
+ * for you.
+ *
+ * Do ***NOT*** use `co_yield` as there is no
+ * equivalent concept in `Ev::Io`; either you
+ * `co_await` (== `then`) or you `co_return`
+ * (== `Ev::lift`).
+ *
+ * Note that using coroutines increases memory
+ * consumption, but now you can get rid of explicit
+ * "context" objects whose sole purpose is just to
+ * hold on to some objects for you while you thread a
+ * gauntlet of `then` boundaries.
+ */
+namespace Ev::coroutine {
+
+class ToBeCleaned;
+
+/* Function that schedules an item to be cleaned up.  */
+void schedule_for_cleaning(ToBeCleaned*) noexcept;
+/* Function used internally by the cleanup procedure.  */
+void do_cleaning_as_scheduled();
+
+/* Base class for things that need cleaning up.
+
+C++20 assumes that the coroutine return object is the
+one responsible for calling `std::coroutine_handle::destroy`,
+possibly even before the coroutine ends.
+In our context, that would be `Ev::Io`, but we do not want
+to modify that because it involves a lot of template
+metaprogramming that I would rather not dig into again.
+
+Now, every coroutine has a "final suspend" that it performs
+when execution leaves the coroutine (past the end, or by
+`co_return`), but that final suspend also *cannot* call
+the `destroy` member function because apparently the compiler
+still writes some stuff to the coroutine object even after
+the final suspend.
+
+What we do instead is that at final suspend, we schedule
+the `std::coroutine_handle::destroy` to be called later,
+at an idle handler.
+
+This is a singly-linked embedded list because one of the
+possible things that can cause something to be cleaned
+up is `std::bad_alloc`, a.k.a. out-of-memory.
+We thus cannot use something like a
+`std::vector<ToBeCleaned*>` to track the items to be
+ccleaned up later, as inserting a new item to that
+structure may cause allocation.
+With the singly-linked embedded list, the coroutine
+itself has the necessary space to maintain the list
+of items to be cleaned up, so no extra allocations are
+needed and there is no possibility of *another*
+`std::bad_alloc` while we are already cleaning up after
+one.
+*/
+class ToBeCleaned {
+private:
+	ToBeCleaned* next;
+
+	friend void schedule_for_cleaning(ToBeCleaned*) noexcept;
+	friend void do_cleaning_as_scheduled();
+
+public:
+	ToBeCleaned() : next(nullptr) { }
+	virtual void clean() =0;
+};
+
+/* Base class for `IoAwaiter` below.  */
+class IoAwaiterBase {
+protected:
+	std::exception_ptr error;
+
+public:
+	IoAwaiterBase() : error(nullptr) { }
+	bool await_ready() const noexcept { return false; }
+};
+
+/* Class for awaiting for another `Ev::Io` via
+`co_await` syntax.
+The promise constructs this class from some concrete
+`Ev::Io` that is the result of the expression after
+`co_await`.
+*/
+template<typename a>
+class IoAwaiter : public IoAwaiterBase {
+private:
+	std::unique_ptr<a> pvalue;
+	Ev::Io<a> act;
+
+public:
+	IoAwaiter() =delete;
+	IoAwaiter( Ev::Io<a> act_
+		 ) : IoAwaiterBase()
+		   , pvalue(nullptr)
+		   , act(std::move(act_))
+		   { }
+	void await_suspend(std::coroutine_handle<> caller) {
+		/* This is arguably a hack, TODO: we should
+		probably make IoAwaiter a friend of Ev::Io so
+		that IoAwaiter can peek at the `core` function
+		directly, which lets us remove some of the
+		overhead `run` adds.
+		*/
+		std::move(act).run([this, caller](a value) {
+			pvalue = std::make_unique<a>(
+				std::move(value)
+			);
+			caller.resume();
+		}, [this, caller](std::exception_ptr e) {
+			error = e;
+			caller.resume();
+		});
+	}
+	a await_resume() {
+		if (error) {
+			std::rethrow_exception(error);
+		}
+		return std::move(*pvalue);
+	}
+};
+template<>
+class IoAwaiter<void>: public IoAwaiterBase {
+private:
+	Ev::Io<void> act;
+
+public:
+	IoAwaiter() =delete;
+	IoAwaiter( Ev::Io<void> act_
+		 ) : IoAwaiterBase()
+		   , act(std::move(act_))
+		   { }
+	void await_suspend(std::coroutine_handle<> caller) {
+		/* See TODO note above for the generic version.  */
+		std::move(act).run([this, caller]() {
+			caller.resume();
+		}, [this, caller](std::exception_ptr e) {
+			error = e;
+			caller.resume();
+		});
+	}
+	void await_resume() {
+		if (error) {
+			std::rethrow_exception(error);
+		}
+	}
+};
+
+template<typename a> class Promise;
+
+/* Class for awaiting a coroutine function when it has
+terminated.
+*/
+template<typename a>
+class FinalSuspendAwaiter {
+public:
+	FinalSuspendAwaiter() { }
+
+	/*---- Expected by compiler. ----*/
+	bool await_ready() const noexcept { return false; }
+	void await_suspend(std::coroutine_handle<Promise<a>> func) noexcept {
+		/* We are going to be suspended now, so arrange
+		to be cleaned up by the main loop.
+		We cannot cleanup *right here* though, which is
+		why we defer the cleanup when the main loop
+		regains control.
+		*/
+		auto promise = &func.promise();
+		schedule_for_cleaning((ToBeCleaned*) promise);
+	}
+	void await_resume() noexcept {
+		/* Should never be called; the entire *point*
+		of the final-suspend is that the coroutine is
+		suspended and never resumed because it is
+		*final*.
+		*/
+		std::terminate();
+	}
+	/*---- Expected by compiler ends. ----*/
+};
+
+class PromiseBase : public ToBeCleaned {
+protected:
+	typedef std::function<void(std::exception_ptr)> FailF;
+
+	std::exception_ptr error;
+	FailF fail;
+
+	virtual void clear_pass() =0;
+
+public:
+	PromiseBase() : ToBeCleaned()
+		      , error(nullptr)
+		      , fail(nullptr)
+		      { }
+
+	/*---- Expected by compiler.  ----*/
+	/* Called when an exception is caught by the
+	compiler at the boundaries of the coroutine
+	function.
+	*/
+	void unhandled_exception() {
+		auto e = std::current_exception();
+		if (fail) {
+			clear_pass();
+			std::move(fail)(std::move(e));
+			return;
+		}
+		error = std::move(e);
+	}
+	/* Called on entry to a coroutine function.
+
+	Ideally this would be `std::suspend_always`,
+	but that lets the function return immediately
+	with a suspended `Ev::Io`, which can then
+	*immediately* have its `run()` member function
+	called, without being un-suspended.
+	Possibly the correct thing to do would be to
+	`resume` in the core function of the returned
+	`Ev::Io`, but I have not gotten around to
+	experimenting with that and figuring out how
+	to combine coroutines with `Ev::Io` is painful
+	enough already.
+	*/
+	std::suspend_never initial_suspend() noexcept {
+		return std::suspend_never();
+	}
+	/* Called on co_await.
+	We accept any `Ev::Io` and arrange a waiter for
+	it.
+	*/
+	template<typename a>
+	IoAwaiter<a> await_transform(Ev::Io<a> act) {
+		return IoAwaiter<a>(std::move(act));
+	}
+	/*---- Expected by compiler ends.  ----*/
+};
+
+template<typename a>
+class PromiseMid : public PromiseBase {
+private:
+	/* From ToBeCleaned.  */
+	void clean() override {
+		auto handle = std::coroutine_handle<Promise<a>>::from_promise(
+			*static_cast<Promise<a>*>(this)
+		);
+		handle.destroy();
+	}
+
+public:
+	/*---- Expected by compiler. ----*/
+	/* Called on exit from the coroutine, whether by
+	exception, reaching the terminating curly brace, or
+	`co_return`.
+	This is waited on *after* the `return_value`,
+	`return_void`, or `unhandled_exception` is called,
+	and after the coroutine internal variables have been
+	destructed, but apparently the compiler still feels
+	the need to poke more bytes at the underlying coroutine
+	object even after successful suspension.
+	*/
+	FinalSuspendAwaiter<a> final_suspend() noexcept {
+		return FinalSuspendAwaiter<a>();
+	}
+	/*---- Expected by compiler ends. ----*/
+};
+
+template<typename a>
+class Promise : public PromiseMid<a> {
+private:
+	typedef PromiseBase::FailF FailF;
+	typedef std::function<void(a)> PassF;
+
+	std::unique_ptr<a> pvalue;
+	PassF pass;
+
+	/* From PromiseBase.  */
+	void clear_pass() override {
+		pass = nullptr;
+	}
+
+public:
+	Promise() : PromiseMid<a>()
+		  , pvalue(nullptr)
+		  , pass(nullptr)
+		  { }
+
+	/*---- Expected by compiler. ----*/
+	/* Integration of the coroutines to the Ev::Io.  */
+	Ev::Io<a> get_return_object() {
+		return Ev::Io<a>([this
+				 ]( PassF f_pass
+				  , FailF f_fail
+				  ) {
+			if (pvalue) {
+				f_fail = nullptr;
+				std::move(f_pass)(std::move(*pvalue));
+				return;
+			}
+			/* For some reason the compiler
+			has difficulty figuring out what
+			this `error` is.
+			*/
+			if (PromiseBase::error) {
+				f_pass = nullptr;
+				std::move(f_fail)(std::move(PromiseBase::error));
+				return;
+			}
+			pass = std::move(f_pass);
+			PromiseBase::fail = std::move(f_fail);
+		});
+	}
+	void return_value(a value) {
+		if (pass) {
+			PromiseBase::fail = nullptr;
+			std::move(pass)(std::move(value));
+			return;
+		}
+		pvalue = std::make_unique<a>(
+			std::move(value)
+		);
+	}
+	/*---- Expected by compiler ends. ----*/
+};
+
+template<>
+class Promise<void> : public PromiseMid<void> {
+private:
+	typedef std::function<void()> PassF;
+
+	bool done;
+	PassF pass;
+
+public:
+	Promise() : PromiseMid<void>()
+		  , done(false)
+		  , pass(nullptr)
+		  { }
+
+	/*---- Expected by compiler. ----*/
+	Ev::Io<void> get_return_object() {
+		return Ev::Io<void>([this]( PassF f_pass
+					  , FailF f_fail
+					  ) {
+			if (done) {
+				f_fail = nullptr;
+				std::move(f_pass)();
+				return;
+			}
+			if (error) {
+				f_pass = nullptr;
+				std::move(f_fail)(std::move(error));
+				return;
+			}
+			pass = std::move(f_pass);
+			fail = std::move(f_fail);
+		});
+	}
+	void return_void() {
+		if (pass) {
+			fail = nullptr;
+			std::move(pass)();
+			return;
+		}
+		done = true;
+	}
+	/*---- Expected by compiler ends. ----*/
+};
+
+}
+
+/* Tell the compiler that `Ev::Io<a>` has coroutine
+support now.
+*/
+template<typename a, typename... As>
+struct std::coroutine_traits<Ev::Io<a>, As...> {
+	using promise_type = Ev::coroutine::Promise<a>;
+};
+
+#endif /* !defined(EV_COROUTINE_HPP) */

--- a/Ev/coroutine.hpp
+++ b/Ev/coroutine.hpp
@@ -476,9 +476,10 @@ void FinalSuspendAwaiter<a>::await_suspend(std::coroutine_handle<Promise<a>> fun
 /* Tell the compiler that `Ev::Io<a>` has coroutine
 support now.
 */
+namespace std {
 template<typename a, typename... As>
-struct std::coroutine_traits<Ev::Io<a>, As...> {
+struct coroutine_traits<Ev::Io<a>, As...> {
 	using promise_type = Ev::coroutine::Promise<a>;
 };
-
+} // namespace std
 #endif /* !defined(EV_COROUTINE_HPP) */

--- a/Ev/coroutine.hpp
+++ b/Ev/coroutine.hpp
@@ -61,7 +61,7 @@ possible things that can cause something to be cleaned
 up is `std::bad_alloc`, a.k.a. out-of-memory.
 We thus cannot use something like a
 `std::vector<ToBeCleaned*>` to track the items to be
-ccleaned up later, as inserting a new item to that
+cleaned up later, as inserting a new item to that
 structure may cause allocation.
 With the singly-linked embedded list, the coroutine
 itself has the necessary space to maintain the list

--- a/Ev/coroutine.hpp
+++ b/Ev/coroutine.hpp
@@ -368,6 +368,11 @@ private:
 	bool done;
 	PassF pass;
 
+	/* From PromiseBase.  */
+	void clear_pass() override {
+		pass = nullptr;
+	}
+
 public:
 	Promise() : PromiseMid<void>()
 		  , done(false)

--- a/Ev/coroutine.hpp
+++ b/Ev/coroutine.hpp
@@ -159,12 +159,7 @@ public:
 		   { }
 	void await_suspend(std::coroutine_handle<> caller) {
 		/* See TODO note above for the generic version.  */
-		std::move(act).run([this, caller]() {
-			try {
-				/* nothing */
-			} catch (...) {
-				error = std::current_exception();
-			}
+		std::move(act).run([caller]() {
 			caller.resume();
 		}, [this, caller](std::exception_ptr e) {
 			error = e;

--- a/Ev/coroutine.hpp
+++ b/Ev/coroutine.hpp
@@ -122,9 +122,11 @@ public:
 		overhead `run` adds.
 		*/
 		std::move(act).run([this, caller](a value) {
-			pvalue = std::make_unique<a>(
-				std::move(value)
-			);
+			try {
+				pvalue = std::make_unique<a>(std::move(value));
+			} catch (...) {
+				error = std::current_exception();
+			}
 			caller.resume();
 		}, [this, caller](std::exception_ptr e) {
 			error = e;
@@ -152,6 +154,11 @@ public:
 	void await_suspend(std::coroutine_handle<> caller) {
 		/* See TODO note above for the generic version.  */
 		std::move(act).run([this, caller]() {
+			try {
+				/* nothing */
+			} catch (...) {
+				error = std::current_exception();
+			}
 			caller.resume();
 		}, [this, caller](std::exception_ptr e) {
 			error = e;

--- a/Ev/coroutine.hpp
+++ b/Ev/coroutine.hpp
@@ -37,7 +37,7 @@ class ToBeCleaned;
 /* Function that schedules an item to be cleaned up.  */
 void schedule_for_cleaning(ToBeCleaned*) noexcept;
 /* Function used internally by the cleanup procedure.  */
-void do_cleaning_as_scheduled();
+void do_cleaning_as_scheduled() noexcept;
 
 /* Base class for things that need cleaning up.
 
@@ -78,7 +78,7 @@ private:
 	ToBeCleaned* next;
 
 	friend void schedule_for_cleaning(ToBeCleaned*) noexcept;
-	friend void do_cleaning_as_scheduled();
+	friend void do_cleaning_as_scheduled() noexcept;
 
 public:
 	ToBeCleaned() : next(nullptr) { }

--- a/Ev/coroutine.hpp
+++ b/Ev/coroutine.hpp
@@ -2,7 +2,10 @@
 #define EV_COROUTINE_HPP
 
 #include"Ev/Io.hpp"
-#include<coroutine>
+#include <coroutine>
+#include<exception>
+#include<functional>
+#include<memory>
 #include<utility>
 
 /** Contains support for using `Ev::Io` in C++20

--- a/Makefile.am
+++ b/Makefile.am
@@ -406,6 +406,8 @@ libclboss_la_SOURCES = \
 	Ev/ThreadPool.hpp \
 	Ev/concurrent.cpp \
 	Ev/concurrent.hpp \
+	Ev/coroutine.cpp \
+	Ev/coroutine.hpp \
 	Ev/foreach.hpp \
 	Ev/map.hpp \
 	Ev/memoize.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -629,6 +629,7 @@ TESTS = \
 	tests/ev/test_memoize \
 	tests/ev/test_plus \
 	tests/ev/test_coroutine_cleanup \
+	tests/ev/test_coroutine_unattached_leak \
 	tests/ev/test_runcmd \
 	tests/ev/test_semaphore \
 	tests/ev/test_throw_in_then \

--- a/Makefile.am
+++ b/Makefile.am
@@ -630,6 +630,8 @@ TESTS = \
 	tests/ev/test_plus \
 	tests/ev/test_coroutine_cleanup \
 	tests/ev/test_coroutine_unattached_leak \
+	tests/ev/test_coroutine_attached_before_finalize \
+	tests/ev/test_coroutine_io_gone_before_finalize \
 	tests/ev/test_runcmd \
 	tests/ev/test_semaphore \
 	tests/ev/test_throw_in_then \

--- a/Makefile.am
+++ b/Makefile.am
@@ -628,6 +628,7 @@ TESTS = \
 	tests/ev/test_map \
 	tests/ev/test_memoize \
 	tests/ev/test_plus \
+	tests/ev/test_coroutine_cleanup \
 	tests/ev/test_runcmd \
 	tests/ev/test_semaphore \
 	tests/ev/test_throw_in_then \

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AS_IF([test ${clboss_set_CXXFLAGS}], [
 		CXXFLAGS=""
 	])
 ])
-AX_CXX_COMPILE_STDCXX([17])
+AX_CXX_COMPILE_STDCXX([20], , [mandatory])
 AC_LANG([C++])
 
 AC_PROG_AWK

--- a/m4/m4_ax_cxx_compile_stdcxx.m4
+++ b/m4/m4_ax_cxx_compile_stdcxx.m4
@@ -1,0 +1,1070 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_cxx_compile_stdcxx.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#
+# DESCRIPTION
+#
+#   Check for baseline language coverage in the compiler for the specified
+#   version of the C++ standard.  If necessary, add switches to CXX and
+#   CXXCPP to enable support.  VERSION may be '11', '14', '17', '20', or
+#   '23' for the respective C++ standard version.
+#
+#   The second argument, if specified, indicates whether you insist on an
+#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
+#   -std=c++11).  If neither is specified, you get whatever works, with
+#   preference for no added switch, and then for an extended mode.
+#
+#   The third argument, if specified 'mandatory' or if left unspecified,
+#   indicates that baseline support for the specified C++ standard is
+#   required and that the macro should error out if no mode with that
+#   support is found.  If specified 'optional', then configuration proceeds
+#   regardless, after defining HAVE_CXX${VERSION} if and only if a
+#   supporting mode is found.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Benjamin Kosnik <bkoz@redhat.com>
+#   Copyright (c) 2012 Zack Weinberg <zackw@panix.com>
+#   Copyright (c) 2013 Roy Stogner <roystgnr@ices.utexas.edu>
+#   Copyright (c) 2014, 2015 Google Inc.; contributed by Alexey Sokolov <sokolov@google.com>
+#   Copyright (c) 2015 Paul Norman <penorman@mac.com>
+#   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
+#   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
+#   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
+#   Copyright (c) 2020 Jason Merrill <jason@redhat.com>
+#   Copyright (c) 2021, 2024 Jörn Heusipp <osmanx@problemloesungsmaschine.de>
+#   Copyright (c) 2015, 2022, 2023, 2024 Olly Betts
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 25
+
+dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
+dnl  (serial version number 13).
+
+AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
+  m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
+        [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
+        [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [$1], [20], [ax_cxx_compile_alternatives="20"],
+        [$1], [23], [ax_cxx_compile_alternatives="23"],
+        [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$2], [], [],
+        [$2], [ext], [],
+        [$2], [noext], [],
+        [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
+  m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
+        [$3], [optional], [ax_cxx_compile_cxx$1_required=false],
+        [m4_fatal([invalid third argument `$3' to AX_CXX_COMPILE_STDCXX])])
+  AC_LANG_PUSH([C++])dnl
+  ac_success=no
+
+  m4_if([$2], [], [dnl
+    AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+		   ax_cv_cxx_compile_cxx$1,
+      [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+        [ax_cv_cxx_compile_cxx$1=yes],
+        [ax_cv_cxx_compile_cxx$1=no])])
+    if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+      ac_success=yes
+    fi])
+
+  m4_if([$2], [noext], [], [dnl
+  if test x$ac_success = xno; then
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      switch="-std=gnu++${alternative}"
+      cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                     $cachevar,
+        [ac_save_CXX="$CXX"
+         CXX="$CXX $switch"
+         AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+          [eval $cachevar=yes],
+          [eval $cachevar=no])
+         CXX="$ac_save_CXX"])
+      if eval test x\$$cachevar = xyes; then
+        CXX="$CXX $switch"
+        if test -n "$CXXCPP" ; then
+          CXXCPP="$CXXCPP $switch"
+        fi
+        ac_success=yes
+        break
+      fi
+    done
+  fi])
+
+  m4_if([$2], [ext], [], [dnl
+  if test x$ac_success = xno; then
+    dnl HP's aCC needs +std=c++11 according to:
+    dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
+    dnl Cray's crayCC needs "-h std=c++11"
+    dnl MSVC needs -std:c++NN for C++17 and later (default is C++14)
+    for alternative in ${ax_cxx_compile_alternatives}; do
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}" MSVC; do
+        if test x"$switch" = xMSVC; then
+          dnl AS_TR_SH maps both `:` and `=` to `_` so -std:c++17 would collide
+          dnl with -std=c++17.  We suffix the cache variable name with _MSVC to
+          dnl avoid this.
+          switch=-std:c++${alternative}
+          cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_${switch}_MSVC])
+        else
+          cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        fi
+        AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
+                       $cachevar,
+          [ac_save_CXX="$CXX"
+           CXX="$CXX $switch"
+           AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+            [eval $cachevar=yes],
+            [eval $cachevar=no])
+           CXX="$ac_save_CXX"])
+        if eval test x\$$cachevar = xyes; then
+          CXX="$CXX $switch"
+          if test -n "$CXXCPP" ; then
+            CXXCPP="$CXXCPP $switch"
+          fi
+          ac_success=yes
+          break
+        fi
+      done
+      if test x$ac_success = xyes; then
+        break
+      fi
+    done
+  fi])
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  fi
+  if test x$ac_success = xno; then
+    HAVE_CXX$1=0
+    AC_MSG_NOTICE([No compiler with C++$1 support was found])
+  else
+    HAVE_CXX$1=1
+    AC_DEFINE(HAVE_CXX$1,1,
+              [define if the compiler supports basic C++$1 syntax])
+  fi
+  AC_SUBST(HAVE_CXX$1)
+])
+
+
+dnl  Test body for checking C++11 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11]
+)
+
+dnl  Test body for checking C++14 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14]
+)
+
+dnl  Test body for checking C++17 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17]
+)
+
+dnl  Test body for checking C++20 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_20],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20]
+)
+
+dnl  Test body for checking C++23 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_23],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_23]
+)
+
+
+dnl  Tests for new features in C++11
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
+
+// If the compiler admits that it is not ready for C++11, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+// MSVC always sets __cplusplus to 199711L in older versions; newer versions
+// only set it correctly if /Zc:__cplusplus is specified as well as a
+// /std:c++NN switch:
+//
+// https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+//
+// The value __cplusplus ought to have is available in _MSVC_LANG since
+// Visual Studio 2015 Update 3:
+//
+// https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+//
+// This was also the first MSVC version to support C++14 so we can't use the
+// value of either __cplusplus or _MSVC_LANG to quickly rule out MSVC having
+// C++11 or C++14 support, but we can check _MSVC_LANG for C++17 and later.
+#elif __cplusplus < 201103L && !defined _MSC_VER
+
+#error "This is not a C++11 compiler"
+
+#else
+
+namespace cxx11
+{
+
+  namespace test_static_assert
+  {
+
+    template <typename T>
+    struct check
+    {
+      static_assert(sizeof(int) <= sizeof(T), "not big enough");
+    };
+
+  }
+
+  namespace test_final_override
+  {
+
+    struct Base
+    {
+      virtual ~Base() {}
+      virtual void f() {}
+    };
+
+    struct Derived : public Base
+    {
+      virtual ~Derived() override {}
+      virtual void f() override {}
+    };
+
+  }
+
+  namespace test_double_right_angle_brackets
+  {
+
+    template < typename T >
+    struct check {};
+
+    typedef check<void> single_type;
+    typedef check<check<void>> double_type;
+    typedef check<check<check<void>>> triple_type;
+    typedef check<check<check<check<void>>>> quadruple_type;
+
+  }
+
+  namespace test_decltype
+  {
+
+    int
+    f()
+    {
+      int a = 1;
+      decltype(a) b = 2;
+      return a + b;
+    }
+
+  }
+
+  namespace test_type_deduction
+  {
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static const bool value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static const bool value = true;
+    };
+
+    template < typename T1, typename T2 >
+    auto
+    add(T1 a1, T2 a2) -> decltype(a1 + a2)
+    {
+      return a1 + a2;
+    }
+
+    int
+    test(const int c, volatile int v)
+    {
+      static_assert(is_same<int, decltype(0)>::value == true, "");
+      static_assert(is_same<int, decltype(c)>::value == false, "");
+      static_assert(is_same<int, decltype(v)>::value == false, "");
+      auto ac = c;
+      auto av = v;
+      auto sumi = ac + av + 'x';
+      auto sumf = ac + av + 1.0;
+      static_assert(is_same<int, decltype(ac)>::value == true, "");
+      static_assert(is_same<int, decltype(av)>::value == true, "");
+      static_assert(is_same<int, decltype(sumi)>::value == true, "");
+      static_assert(is_same<int, decltype(sumf)>::value == false, "");
+      static_assert(is_same<int, decltype(add(c, v))>::value == true, "");
+      return (sumf > 0.0) ? sumi : add(c, v);
+    }
+
+  }
+
+  namespace test_noexcept
+  {
+
+    int f() { return 0; }
+    int g() noexcept { return 0; }
+
+    static_assert(noexcept(f()) == false, "");
+    static_assert(noexcept(g()) == true, "");
+
+  }
+
+  namespace test_constexpr
+  {
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c_r(const CharT *const s, const unsigned long acc) noexcept
+    {
+      return *s ? strlen_c_r(s + 1, acc + 1) : acc;
+    }
+
+    template < typename CharT >
+    unsigned long constexpr
+    strlen_c(const CharT *const s) noexcept
+    {
+      return strlen_c_r(s, 0UL);
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("1") == 1UL, "");
+    static_assert(strlen_c("example") == 7UL, "");
+    static_assert(strlen_c("another\0example") == 7UL, "");
+
+  }
+
+  namespace test_rvalue_references
+  {
+
+    template < int N >
+    struct answer
+    {
+      static constexpr int value = N;
+    };
+
+    answer<1> f(int&)       { return answer<1>(); }
+    answer<2> f(const int&) { return answer<2>(); }
+    answer<3> f(int&&)      { return answer<3>(); }
+
+    void
+    test()
+    {
+      int i = 0;
+      const int c = 0;
+      static_assert(decltype(f(i))::value == 1, "");
+      static_assert(decltype(f(c))::value == 2, "");
+      static_assert(decltype(f(0))::value == 3, "");
+    }
+
+  }
+
+  namespace test_uniform_initialization
+  {
+
+    struct test
+    {
+      static const int zero {};
+      static const int one {1};
+    };
+
+    static_assert(test::zero == 0, "");
+    static_assert(test::one == 1, "");
+
+  }
+
+  namespace test_lambdas
+  {
+
+    void
+    test1()
+    {
+      auto lambda1 = [](){};
+      auto lambda2 = lambda1;
+      lambda1();
+      lambda2();
+    }
+
+    int
+    test2()
+    {
+      auto a = [](int i, int j){ return i + j; }(1, 2);
+      auto b = []() -> int { return '0'; }();
+      auto c = [=](){ return a + b; }();
+      auto d = [&](){ return c; }();
+      auto e = [a, &b](int x) mutable {
+        const auto identity = [](int y){ return y; };
+        for (auto i = 0; i < a; ++i)
+          a += b--;
+        return x + identity(a + b);
+      }(0);
+      return a + b + c + d + e;
+    }
+
+    int
+    test3()
+    {
+      const auto nullary = [](){ return 0; };
+      const auto unary = [](int x){ return x; };
+      using nullary_t = decltype(nullary);
+      using unary_t = decltype(unary);
+      const auto higher1st = [](nullary_t f){ return f(); };
+      const auto higher2nd = [unary](nullary_t f1){
+        return [unary, f1](unary_t f2){ return f2(unary(f1())); };
+      };
+      return higher1st(nullary) + higher2nd(nullary)(unary);
+    }
+
+  }
+
+  namespace test_variadic_templates
+  {
+
+    template <int...>
+    struct sum;
+
+    template <int N0, int... N1toN>
+    struct sum<N0, N1toN...>
+    {
+      static constexpr auto value = N0 + sum<N1toN...>::value;
+    };
+
+    template <>
+    struct sum<>
+    {
+      static constexpr auto value = 0;
+    };
+
+    static_assert(sum<>::value == 0, "");
+    static_assert(sum<1>::value == 1, "");
+    static_assert(sum<23>::value == 23, "");
+    static_assert(sum<1, 2>::value == 3, "");
+    static_assert(sum<5, 5, 11>::value == 21, "");
+    static_assert(sum<2, 3, 5, 7, 11, 13>::value == 41, "");
+
+  }
+
+  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
+  // because of this.
+  namespace test_template_alias_sfinae
+  {
+
+    struct foo {};
+
+    template<typename T>
+    using member = typename T::member_type;
+
+    template<typename T>
+    void func(...) {}
+
+    template<typename T>
+    void func(member<T>*) {}
+
+    void test();
+
+    void test() { func<foo>(0); }
+
+  }
+
+}  // namespace cxx11
+
+#endif  // __cplusplus >= 201103L
+
+]])
+
+
+dnl  Tests for new features in C++14
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
+
+// If the compiler admits that it is not ready for C++14, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif __cplusplus < 201402L && !defined _MSC_VER
+
+#error "This is not a C++14 compiler"
+
+#else
+
+namespace cxx14
+{
+
+  namespace test_polymorphic_lambdas
+  {
+
+    int
+    test()
+    {
+      const auto lambda = [](auto&&... args){
+        const auto istiny = [](auto x){
+          return (sizeof(x) == 1UL) ? 1 : 0;
+        };
+        const int aretiny[] = { istiny(args)... };
+        return aretiny[0];
+      };
+      return lambda(1, 1L, 1.0f, '1');
+    }
+
+  }
+
+  namespace test_binary_literals
+  {
+
+    constexpr auto ivii = 0b0000000000101010;
+    static_assert(ivii == 42, "wrong value");
+
+  }
+
+  namespace test_generalized_constexpr
+  {
+
+    template < typename CharT >
+    constexpr unsigned long
+    strlen_c(const CharT *const s) noexcept
+    {
+      auto length = 0UL;
+      for (auto p = s; *p; ++p)
+        ++length;
+      return length;
+    }
+
+    static_assert(strlen_c("") == 0UL, "");
+    static_assert(strlen_c("x") == 1UL, "");
+    static_assert(strlen_c("test") == 4UL, "");
+    static_assert(strlen_c("another\0test") == 7UL, "");
+
+  }
+
+  namespace test_lambda_init_capture
+  {
+
+    int
+    test()
+    {
+      auto x = 0;
+      const auto lambda1 = [a = x](int b){ return a + b; };
+      const auto lambda2 = [a = lambda1(x)](){ return a; };
+      return lambda2();
+    }
+
+  }
+
+  namespace test_digit_separators
+  {
+
+    constexpr auto ten_million = 100'000'000;
+    static_assert(ten_million == 100000000, "");
+
+  }
+
+  namespace test_return_type_deduction
+  {
+
+    auto f(int& x) { return x; }
+    decltype(auto) g(int& x) { return x; }
+
+    template < typename T1, typename T2 >
+    struct is_same
+    {
+      static constexpr auto value = false;
+    };
+
+    template < typename T >
+    struct is_same<T, T>
+    {
+      static constexpr auto value = true;
+    };
+
+    int
+    test()
+    {
+      auto x = 0;
+      static_assert(is_same<int, decltype(f(x))>::value, "");
+      static_assert(is_same<int&, decltype(g(x))>::value, "");
+      return x;
+    }
+
+  }
+
+}  // namespace cxx14
+
+#endif  // __cplusplus >= 201402L
+
+]])
+
+
+dnl  Tests for new features in C++17
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
+
+// If the compiler admits that it is not ready for C++17, why torture it?
+// Hopefully, this will speed up the test.
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
+
+#error "This is not a C++17 compiler"
+
+#else
+
+#include <initializer_list>
+#include <utility>
+#include <type_traits>
+
+namespace cxx17
+{
+
+  namespace test_constexpr_lambdas
+  {
+
+    constexpr int foo = [](){return 42;}();
+
+  }
+
+  namespace test::nested_namespace::definitions
+  {
+
+  }
+
+  namespace test_fold_expression
+  {
+
+    template<typename... Args>
+    int multiply(Args... args)
+    {
+      return (args * ... * 1);
+    }
+
+    template<typename... Args>
+    bool all(Args... args)
+    {
+      return (args && ...);
+    }
+
+  }
+
+  namespace test_extended_static_assert
+  {
+
+    static_assert (true);
+
+  }
+
+  namespace test_auto_brace_init_list
+  {
+
+    auto foo = {5};
+    auto bar {5};
+
+    static_assert(std::is_same<std::initializer_list<int>, decltype(foo)>::value);
+    static_assert(std::is_same<int, decltype(bar)>::value);
+  }
+
+  namespace test_typename_in_template_template_parameter
+  {
+
+    template<template<typename> typename X> struct D;
+
+  }
+
+  namespace test_fallthrough_nodiscard_maybe_unused_attributes
+  {
+
+    int f1()
+    {
+      return 42;
+    }
+
+    [[nodiscard]] int f2()
+    {
+      [[maybe_unused]] auto unused = f1();
+
+      switch (f1())
+      {
+      case 17:
+        f1();
+        [[fallthrough]];
+      case 42:
+        f1();
+      }
+      return f1();
+    }
+
+  }
+
+  namespace test_extended_aggregate_initialization
+  {
+
+    struct base1
+    {
+      int b1, b2 = 42;
+    };
+
+    struct base2
+    {
+      base2() {
+        b3 = 42;
+      }
+      int b3;
+    };
+
+    struct derived : base1, base2
+    {
+        int d;
+    };
+
+    derived d1 {{1, 2}, {}, 4};  // full initialization
+    derived d2 {{}, {}, 4};      // value-initialized bases
+
+  }
+
+  namespace test_general_range_based_for_loop
+  {
+
+    struct iter
+    {
+      int i;
+
+      int& operator* ()
+      {
+        return i;
+      }
+
+      const int& operator* () const
+      {
+        return i;
+      }
+
+      iter& operator++()
+      {
+        ++i;
+        return *this;
+      }
+    };
+
+    struct sentinel
+    {
+      int i;
+    };
+
+    bool operator== (const iter& i, const sentinel& s)
+    {
+      return i.i == s.i;
+    }
+
+    bool operator!= (const iter& i, const sentinel& s)
+    {
+      return !(i == s);
+    }
+
+    struct range
+    {
+      iter begin() const
+      {
+        return {0};
+      }
+
+      sentinel end() const
+      {
+        return {5};
+      }
+    };
+
+    void f()
+    {
+      range r {};
+
+      for (auto i : r)
+      {
+        [[maybe_unused]] auto v = i;
+      }
+    }
+
+  }
+
+  namespace test_lambda_capture_asterisk_this_by_value
+  {
+
+    struct t
+    {
+      int i;
+      int foo()
+      {
+        return [*this]()
+        {
+          return i;
+        }();
+      }
+    };
+
+  }
+
+  namespace test_enum_class_construction
+  {
+
+    enum class byte : unsigned char
+    {};
+
+    byte foo {42};
+
+  }
+
+  namespace test_constexpr_if
+  {
+
+    template <bool cond>
+    int f ()
+    {
+      if constexpr(cond)
+      {
+        return 13;
+      }
+      else
+      {
+        return 42;
+      }
+    }
+
+  }
+
+  namespace test_selection_statement_with_initializer
+  {
+
+    int f()
+    {
+      return 13;
+    }
+
+    int f2()
+    {
+      if (auto i = f(); i > 0)
+      {
+        return 3;
+      }
+
+      switch (auto i = f(); i + 4)
+      {
+      case 17:
+        return 2;
+
+      default:
+        return 1;
+      }
+    }
+
+  }
+
+  namespace test_template_argument_deduction_for_class_templates
+  {
+
+    template <typename T1, typename T2>
+    struct pair
+    {
+      pair (T1 p1, T2 p2)
+        : m1 {p1},
+          m2 {p2}
+      {}
+
+      T1 m1;
+      T2 m2;
+    };
+
+    void f()
+    {
+      [[maybe_unused]] auto p = pair{13, 42u};
+    }
+
+  }
+
+  namespace test_non_type_auto_template_parameters
+  {
+
+    template <auto n>
+    struct B
+    {};
+
+    B<5> b1;
+    B<'a'> b2;
+
+  }
+
+  namespace test_structured_bindings
+  {
+
+    int arr[2] = { 1, 2 };
+    std::pair<int, int> pr = { 1, 2 };
+
+    auto f1() -> int(&)[2]
+    {
+      return arr;
+    }
+
+    auto f2() -> std::pair<int, int>&
+    {
+      return pr;
+    }
+
+    struct S
+    {
+      int x1 : 2;
+      volatile double y1;
+    };
+
+    S f3()
+    {
+      return {};
+    }
+
+    auto [ x1, y1 ] = f1();
+    auto& [ xr1, yr1 ] = f1();
+    auto [ x2, y2 ] = f2();
+    auto& [ xr2, yr2 ] = f2();
+    const auto [ x3, y3 ] = f3();
+
+  }
+
+  namespace test_exception_spec_type_system
+  {
+
+    struct Good {};
+    struct Bad {};
+
+    void g1() noexcept;
+    void g2();
+
+    template<typename T>
+    Bad
+    f(T*, T*);
+
+    template<typename T1, typename T2>
+    Good
+    f(T1*, T2*);
+
+    static_assert (std::is_same_v<Good, decltype(f(g1, g2))>);
+
+  }
+
+  namespace test_inline_variables
+  {
+
+    template<class T> void f(T)
+    {}
+
+    template<class T> inline T g(T)
+    {
+      return T{};
+    }
+
+    template<> inline void f<>(int)
+    {}
+
+    template<> int g<>(int)
+    {
+      return 5;
+    }
+
+  }
+
+}  // namespace cxx17
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
+
+]])
+
+
+dnl  Tests for new features in C++20
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_20], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+#error "This is not a C++20 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx20
+{
+
+// As C++20 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx20
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+]])
+
+
+dnl  Tests for new features in C++23
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_23], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
+
+#error "This is not a C++23 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx23
+{
+
+// As C++23 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx23
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
+
+]])

--- a/tests/ev/test_coroutine_attached_before_finalize.cpp
+++ b/tests/ev/test_coroutine_attached_before_finalize.cpp
@@ -1,0 +1,19 @@
+#undef NDEBUG
+#include"Ev/coroutine.hpp"
+#include"Ev/start.hpp"
+#include"Ev/yield.hpp"
+#include<assert.h>
+
+Ev::Io<int> attached_before_finalize() {
+	co_await Ev::yield();
+	co_return 0;
+}
+
+int main() {
+	auto io = attached_before_finalize();
+	auto ec = Ev::start(io);
+	assert(ec == 0);
+	Ev::coroutine::do_cleaning_as_scheduled();
+	return 0;
+}
+

--- a/tests/ev/test_coroutine_cleanup.cpp
+++ b/tests/ev/test_coroutine_cleanup.cpp
@@ -1,0 +1,23 @@
+#undef NDEBUG
+#include"Ev/coroutine.hpp"
+#include"Ev/start.hpp"
+#include<assert.h>
+
+/* A coroutine that completes before the caller attaches to the returned Io. */
+Ev::Io<int> already_finished() {
+	co_return 0;
+}
+
+int main() {
+	auto io = already_finished();
+
+	/* Simulate the libev idle handler running before anyone consumes the Io.
+	 * With the current coroutine cleanup scheduling this destroys the promise
+	 * early and the subsequent run would use freed memory.
+	 */
+	Ev::coroutine::do_cleaning_as_scheduled();
+
+	auto ec = Ev::start(io);
+	assert(ec == 0);
+	return 0;
+}

--- a/tests/ev/test_coroutine_io_gone_before_finalize.cpp
+++ b/tests/ev/test_coroutine_io_gone_before_finalize.cpp
@@ -1,0 +1,28 @@
+#undef NDEBUG
+#include"Ev/coroutine.hpp"
+#include"Ev/start.hpp"
+#include"Ev/yield.hpp"
+#include<assert.h>
+
+[[gnu::noinline]]
+Ev::Io<int> io_gone_before_finalize() {
+	co_await Ev::yield();
+	co_return 0;
+}
+
+[[gnu::noinline]]
+void consume(Ev::Io<int>) { }
+
+int main() {
+	consume(io_gone_before_finalize());
+
+	auto pump = Ev::yield(2).then([]() {
+		return Ev::lift(0);
+	});
+	auto ec = Ev::start(std::move(pump));
+	assert(ec == 0);
+
+	Ev::coroutine::do_cleaning_as_scheduled();
+	return 0;
+}
+

--- a/tests/ev/test_coroutine_unattached_leak.cpp
+++ b/tests/ev/test_coroutine_unattached_leak.cpp
@@ -1,0 +1,18 @@
+#undef NDEBUG
+#include"Ev/coroutine.hpp"
+#include<assert.h>
+
+[[gnu::noinline]]
+Ev::Io<int> already_finished_unattached() {
+	co_return 0;
+}
+
+[[gnu::noinline]]
+void consume(Ev::Io<int>) { }
+
+int main() {
+	consume(already_finished_unattached());
+	Ev::coroutine::do_cleaning_as_scheduled();
+	return 0;
+}
+


### PR DESCRIPTION
Much more convenient to use `co_await` and `co_return` instead of `.then` and `Ev::lift`.  Increases memory use somewhat compared to the classic `Ev::Io` use though.  See the last commit for an example of converting the old style to coroutines.  Loops in particular are AWESOME with coroutine syntax.

I notice `libunwind` tends to massively conflict with `valgrind`, poking at data outside the stack space. As a motivating example I modified `Boss/Mod/FeeModderByPriceTheory.cpp` a little to use a little bit of coroutines, whose `tests/boss/test_feemodderbypricetheory` does not seem to have `libunwindw` conflict with `valgrind`, and using coroutines simplifies the coding somewhat and does not seem to leak as per `valgrind`.

Coroutines are C++20, obviously we need to move to using C++20, including dropping support for environments without it, which I am not sure is an issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds full C++20 coroutine support (Ev::coroutine): awaiters, promise types, final-suspend cleanup scheduling (schedule_for_cleaning / do_cleaning_as_scheduled), example conversion, and Ev/coroutine.cpp/.hpp integrated into the build; notes increased memory use and the author’s warning to avoid anonymous coroutine lambdas (use named/member coroutines or copy captures) and libunwind/valgrind considerations.
- Build/system changes: makes C++20 mandatory (configure.ac), adds a new AX_CXX_COMPILE_STDCXX m4 macro, updates m4 ignore rules, and adds coroutine sources to libclboss_la_SOURCES.
- Tests and hygiene: adds four coroutine-focused tests (cleanup, unattached leak, attached-before-finalize, io-gone-before-finalize), small lambda capture adjustments ([=, this]) across modules, and includes cleanup/idler logic to safely destroy coroutine frames on the main loop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->