### PR TITLE
Build clboss package with nix flake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - uses: actions/checkout@v6
+    - uses: cachix/install-nix-action@v31
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    - run: nix develop --command bash -c "autoreconf -i && ./configure && make -j4 distcheck"
+    - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ test_*
 !test_*.cpp
 !test_*.c
 /commit_hash.h
+result

--- a/contrib-shell.nix
+++ b/contrib-shell.nix
@@ -1,6 +1,8 @@
-{ pkgs ? import (builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz";
-}) {} }:
+{
+  pkgs ? import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz";
+  }) { },
+}:
 
 let
   poetry2nix = import (builtins.fetchGit {
@@ -16,4 +18,3 @@ pkgs.mkShell {
     })
   ];
 }
-

--- a/flake.lock
+++ b/flake.lock
@@ -20,15 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692270513,
-        "narHash": "sha256-xu23SOtq8DhqbFzyr+z89xUMh12J/10eyXrih1ifwq4=",
-        "owner": "nixos",
+        "lastModified": 1759831965,
+        "narHash": "sha256-vgPm2xjOmKdZ0xKA6yLXPJpjOtQPHfaZDRtH+47XEBo=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1abef55f64479d6fcd2c309a00a5ff419e793a85",
+        "rev": "c9b6fb798541223bbb396d287d16f43520250518",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,12 @@
-(import
-  (
-    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
-    fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-      sha256 = lock.nodes.flake-compat.locked.narHash;
-    }
-  )
-  { src = ./.; }
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }
   # Since a lot of existing CI tests is based on `shell.nix`
   # we forward to the integrationTests shell, instead of the
   # default (developer) shell.


### PR DESCRIPTION
- Added a derivation to build the plugin with the nix flake.
- Changed URL to be explicit about using unstable branch.
- Switched the latest nixfmt.
- Modified the actions build workflow to run the equivalent `nix build .#`

I'm running this package on my Core Lightning node and its working as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI actions and simplified the build pipeline for faster, more reliable builds.
  * Added an ignore rule to improve build artifact management.

* **New Features**
  * Introduced a packaged build target with accompanying test/check integration.
  * Added an enhanced development shell and a repository formatter to improve developer experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->