### PR TITLE
docs: fixed duplicate sections for earnings reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,36 +375,6 @@ Earlier versions do not record, so if you have been using CLBOSS
 before 0.11D, then historical offchain-to-onchain swaps are not
 reported.
 
-### `clboss-recent-earnings`, `clboss-earnings-history`
-
-As of CLBOSS version [TBD], earnings and expenditures are tracked on a daily basis.
-The following commands have been added to observe the new data:
-
-- **`clboss-recent-earnings`**:
-  - **Purpose**: Returns a data structure equivalent to the
-    `offchain_earnings_tracker` collection in `clboss-status`, but
-    only includes recent earnings and expenditures.
-  - **Arguments**:
-    - `days` (optional): Specifies the number of days to include in
-      the report. Defaults to a fortnight (14 days) if not provided.
-
-- **`clboss-earnings-history`**:
-  - **Purpose**: Provides a daily breakdown of earnings and expenditures.
-  - **Arguments**:
-    - `nodeid` (optional): Limits the history to a particular node if
-      provided. Without this argument, the values are accumulated
-      across all peers.
-  - **Output**: 
-    - The history consists of an array of records showing the earnings
-      and expenditures for each day.
-    - The history includes an initial record with a time value of 0,
-      which contains any legacy earnings and expenditures collected by
-      CLBOSS before daily tracking was implemented.
-
-These commands enhance the tracking of financial metrics, allowing for
-detailed and recent analysis of earnings and expenditures on a daily
-basis.
-
 ### `--clboss-min-onchain=<satoshis>`
 
 Pass this option to `lightningd` in order to specify a target
@@ -521,7 +491,7 @@ The following commands have been added to observe the new data:
   - **Arguments**:
     - `nodeid` (optional): Limits the history to a particular node if
       provided. Without this argument, the history is accumulated
-      across all nodes.
+      across all peers.
   - **Output**: 
     - The history consists of an array of records showing the earnings
       and expenditures for each day.


### PR DESCRIPTION
There were near-identical sections for the earnings reports. The one with the [TBD] placeholder text was removed.