### PR TITLE
Fix fundpsbt arg deprecation using coroutines

### DIFF
--- a/Boss/Mod/OnchainFundsAnnouncer.cpp
+++ b/Boss/Mod/OnchainFundsAnnouncer.cpp
@@ -13,6 +13,7 @@
 #include"Json/Out.hpp"
 #include"S/Bus.hpp"
 #include<cstddef>
+#include<cstdint>
 #include<sstream>
 
 namespace {
@@ -119,7 +120,7 @@ OnchainFundsAnnouncer::fundpsbt() {
 			/* Do not reserve; we just want to know
 			 * how much money could be spent.
 			 */
-			.field("reserve", (double) 0)
+			.field("reserve", std::uint32_t(0))
 		.end_object()
 		;
 	co_return co_await rpc->command("fundpsbt", std::move(params));

--- a/Boss/Mod/OnchainFundsAnnouncer.cpp
+++ b/Boss/Mod/OnchainFundsAnnouncer.cpp
@@ -109,33 +109,6 @@ Ev::Io<void> OnchainFundsAnnouncer::announce() {
 
 Ev::Io<Jsmn::Object>
 OnchainFundsAnnouncer::fundpsbt() {
-	try {
-		/* On old C-Lightning, "reserve" is a bool.
-		 * Try that first.
-		 * If we get a parameter error -32602,
-		 * try with a number 0.
-		 */
-		auto params = Json::Out()
-			.start_object()
-				/* Get all the funds.  */
-				.field("satoshi", std::string("all"))
-				.field("feerate", std::string("normal"))
-				.field("startweight", (double) startweight)
-				.field("minconf", (double) minconf)
-				/* Do not reserve; we just want to know
-				 * how much money could be spent.
-				 */
-				.field("reserve", false)
-			.end_object()
-			;
-		co_return co_await rpc->command("fundpsbt", std::move(params));
-	} catch (RpcError const& e) {
-		/* If not a parameter error, throw.  */
-		if (int(double(e.error["code"])) != -32602) {
-			throw;
-		}
-	}
-	/* Retry with "reserve" as a number.  */
 	auto params = Json::Out()
 		.start_object()
 			/* Get all the funds.  */

--- a/README.md
+++ b/README.md
@@ -561,3 +561,4 @@ The following commands have been added to observe the new data:
 These commands enhance the tracking of financial metrics, allowing for
 detailed and recent analysis of earnings and expenditures on a daily
 basis.
+


### PR DESCRIPTION
This PR fixes #275 , it uses C++20 coroutines to test/validate the approach.

The first commit converts the `OnChainFundsAnnouncer` to the C++20 coroutine version.
The second commit fixes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Converts OnchainFundsAnnouncer to C++20 coroutines (adds Ev/coroutine.hpp, replaces promise chains with co_await/co_return and try/catch).
- Fixes #275 by always passing reserve: 0 as an integer (std::uint32_t(0)) to fundpsbt, removing the boolean-fallback retry and noisy RPC error.
- Preserves external behavior and public signatures while simplifying async flow and improving error logging on fundpsbt failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->