### PR TITLE
Add install-versioned target to facilitate fast roll-forward/roll-back

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -816,6 +816,26 @@ dist-hook:
 
 FORCE:
 
-.PHONY: FORCE
+.PHONY: FORCE install-versioned
+
+CLBOSS_VERSIONED_SYMLINK ?= clboss
+CLBOSS_VERSIONED_DESCRIBE ?=
+
+install-versioned: all
+	@set -e; \
+	describe="$(CLBOSS_VERSIONED_DESCRIBE)"; \
+	if [ -z "$$describe" ]; then \
+		if git -C "$(srcdir)" rev-parse --is-inside-work-tree > /dev/null 2>&1; then \
+			describe="$$(git -C "$(srcdir)" describe --tags --always --dirty)"; \
+		else \
+			describe="v$(PACKAGE_VERSION)"; \
+		fi; \
+	fi; \
+	bindir_path="$(DESTDIR)$(bindir)"; \
+	$(MKDIR_P) "$$bindir_path"; \
+	$(INSTALL_PROGRAM) clboss "$$bindir_path/clboss-$$describe"; \
+	rm -f "$$bindir_path/$(CLBOSS_VERSIONED_SYMLINK)"; \
+	ln -s "clboss-$$describe" "$$bindir_path/$(CLBOSS_VERSIONED_SYMLINK)"; \
+	echo "Installed $$bindir_path/clboss-$$describe and set $$bindir_path/$(CLBOSS_VERSIONED_SYMLINK)"
 
 clboss libclboss.la: $(BUILT_SOURCES)

--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ You will then need to modify your `lightning.conf` to add the
 path to `which clboss` as a `plugin` or `important-plugin` of
 `lightningd`.
 
+For production rollouts/quick rollback, you can install a versioned
+binary and keep `clboss` as a symlink you can switch:
+
+    sudo make install-versioned
+
+This installs `clboss-<git-describe>` (e.g.
+`/usr/local/bin/clboss-v0.15.1-47-g9b61c28`) and updates the symlink
+at `/usr/local/bin/clboss` (or whatever `--prefix` you configured).
+
+To roll back (or switch forward) after multiple installs replace the
+`/usr/local/bin/clboss` symbolic link with one pointing to the
+desired version.
+
 Usually, autotools-based projects like CLBOSS will default
 to using `-g -O2` for compilation flags, where `-g` causes
 the compiler to include debug info.


### PR DESCRIPTION
Normally:
```
make
sudo make install
# installs /usr/local/bin/clboss
```
With this change:
```
make
sudo make install-versioned
```
    
Installs in /usr/local/bin:
```
-rwxr-xr-x  1 root root 228M Dec 18 10:10 clboss-v0.15.1-47-g9b61c28-dirty
-rwxr-xr-x  1 root root 228M Dec 18 10:15 clboss-v0.15.1-48-gfc9a4e2
lrwxrwxrwx  1 root root   26 Dec 18 10:15 clboss -> clboss-v0.15.1-48-gfc9a4e2
```

This is good if you need to experiment w/ rolling clboss forward and back; you can do this by just replacing the symbolic link ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds a new install-versioned make target that installs clboss with a versioned filename (derived from CLBOSS_VERSIONED_DESCRIBE, git describe, or v$(PACKAGE_VERSION)), places the binary in the install prefix, and updates a symlink (default clboss) to the new version to enable quick roll-forward/roll-back.
- Introduces three Makefile variables to control this behavior: CLBOSS_VERSIONED_SYMLINK (default clboss), CLBOSS_VERSIONED_DESCRIBE (override for the version string), and CLBOSS_SWITCH_TO (optional switch target); also marks install-versioned as phony.
- Updates README.md with instructions for the versioned install workflow (sudo make install-versioned) and guidance on switching/rolling back by updating the clboss symlink.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->