### PR TITLE
Fix outdated command reference from 'setchannelfee' to 'setchannel'

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ which has two parameters, `nodeid` and `tags`.
     lightning-cli clboss-unmanage ${NODEID} lnfee
 
 After the above command, you can set the fee manually with
-the normal Core Lightning `setchannelfee` command.
+the normal Core Lightning `setchannel` command.
 
 The second parameter, `tags`, is a string containing a
 comma-separated set of unmanagement tags.


### PR DESCRIPTION
Core-Lightning doesn't support this command in their newest version. It was changed to `setchannel`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates README.md documentation to reflect Core-Lightning's command rename from `setchannelfee` to `setchannel`, ensuring users have the correct command reference for manually setting channel fees after unmanaging a channel.

- Changes only the documentation; no code logic or public API modifications
- Addresses compatibility with Core-Lightning's newest version which removed support for the deprecated `setchannelfee` command
- The codebase already properly uses the `setchannel` command in ChannelFeeSetter implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->