### PR TITLE
contrib: Add debug log postprocessor and fee info plotting utility

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -81,8 +81,9 @@ how many days of earnings history are considered when ranking channels.
   output. `--peer` accepts a nodeid, alias (via lightning-cli/listnodes), or
   SCID (via lightning-cli/listpeerchannels). The combo view includes a daily
   earnings panel (incoming/outgoing msat per day) when lightning-cli is
-  available. Use `--title` to override the plot title (defaults to the peer
-  label; pass empty to omit).
+  available, and the `incoming-earnings`/`outgoing-earnings` views render
+  those panels on their own. Use `--title` to override the plot title
+  (defaults to the peer label; pass empty to omit).
 - **`plot-aggregate`** plots aggregate percentile summaries from the
   `fee-log-parser` sqlite output. Views include
   `baseline-base`, `baseline-ppm`, `size`, `balance`, `theory`,

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -75,3 +75,18 @@ how many days of earnings history are considered when ranking channels.
   accepts the `--days` option.
 - **`recently-closed`** lists channels that closed within the last N days, also
   controlled via `--days`.
+- **`fee-log-parser`** is a parser that streams DEBUG-level logging and writes
+  a sqlite database containing fee algorithm information.
+- **`plot-fees`** plots fee-related time series from the `fee-log-parser` sqlite
+  output. `--peer` accepts a nodeid, alias (via lightning-cli/listnodes), or
+  SCID (via lightning-cli/listpeerchannels). The combo view includes a daily
+  earnings panel (incoming/outgoing msat per day) when lightning-cli is
+  available.
+- **`plot-aggregate`** plots aggregate percentile summaries from the
+  `fee-log-parser` sqlite output. Views include
+  `baseline-base`, `baseline-ppm`, `size`, `balance`, `theory`,
+  `advertised-base`, `advertised-ppm`, `earnings`, and a `combo` view. Each
+  view shows daily
+  p00/p10/p25/p50/p75/p90/p100 percentiles across nodes. The `earnings`
+  view uses `clboss-earnings-history all` to compute net earnings
+  percentiles (sat/day).

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -81,7 +81,8 @@ how many days of earnings history are considered when ranking channels.
   output. `--peer` accepts a nodeid, alias (via lightning-cli/listnodes), or
   SCID (via lightning-cli/listpeerchannels). The combo view includes a daily
   earnings panel (incoming/outgoing msat per day) when lightning-cli is
-  available.
+  available. Use `--title` to override the plot title (defaults to the peer
+  label; pass empty to omit).
 - **`plot-aggregate`** plots aggregate percentile summaries from the
   `fee-log-parser` sqlite output. Views include
   `baseline-base`, `baseline-ppm`, `size`, `balance`, `theory`,

--- a/contrib/fee-log-parser
+++ b/contrib/fee-log-parser
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone
+
+
+LINE_RE = re.compile(
+    r"^(?:\d+:)?(\d{4}-\d{2}-\d{2}T[^ ]+)\s+\w+\s+[^:]+: (.*)$"
+)
+BASELINE_RE = re.compile(r"PeerCompetitorFeeMonitor: Weighted median fees: (.*)$")
+BASELINE_ENTRY_RE = re.compile(r"([0-9a-f]{66})\(b = (\d+), p = (\d+)\)")
+SIZE_RE = re.compile(
+    r"FeeModderBySize: Peer ([0-9a-f]{66}) has (\d+) other peers, "
+    r"(\d+) of which have less capacity than us, (\d+) have more\.\s+"
+    r"Multiplier: ([0-9.]+)"
+)
+BALANCE_MOVED_RE = re.compile(
+    r"FeeModderByBalance: Peer ([0-9a-f]{66}) moved from bin (\d+) to bin (\d+) "
+    r"of (\d+) due to balance (\d+)msat / (\d+)msat: ([0-9.]+)"
+)
+BALANCE_SET_RE = re.compile(
+    r"FeeModderByBalance: Peer ([0-9a-f]{66}) set to bin (\d+) of (\d+) "
+    r"due to balance (\d+)msat / (\d+)msat: ([0-9.]+)"
+)
+PRICE_RE = re.compile(
+    r"FeeModderByPriceTheory: ([0-9a-f]{66}): level = (-?\d+), mult = ([0-9.]+)"
+)
+SETCHANNEL_RE = re.compile(r"^Rpc out: setchannel (.*)$")
+SETCHANNELFEE_RE = re.compile(r"^Rpc out: setchannelfee (.*)$")
+
+ID_RE = re.compile(r'"id"\s*:\s*"([0-9a-f]{66})"')
+FEEBASE_RE = re.compile(r'"feebase"\s*:\s*(\d+)')
+FEEPPM_RE = re.compile(r'"feeppm"\s*:\s*(\d+)')
+BASE_RE = re.compile(r'"base"\s*:\s*(\d+)')
+PPM_RE = re.compile(r'"ppm"\s*:\s*(\d+)')
+
+
+def parse_line(line):
+    line = line.rstrip("\n")
+    m = LINE_RE.match(line)
+    if not m:
+        return None
+    ts, msg = m.group(1), m.group(2)
+    try:
+        ts_epoch = parse_timestamp(ts)
+    except ValueError:
+        return None
+    return ts_epoch, msg, line
+
+
+def local_tz():
+    return datetime.now().astimezone().tzinfo
+
+
+def normalize_dt(dt):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=local_tz())
+    return dt.astimezone(timezone.utc)
+
+
+def parse_timestamp(ts):
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return normalize_dt(datetime.fromisoformat(ts)).timestamp()
+
+
+def parse_json_payload(payload):
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        pass
+    if '\\"' in payload:
+        try:
+            return json.loads(payload.replace('\\"', '"'))
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def parse_setchannel_payload(payload):
+    data = parse_json_payload(payload)
+    if data:
+        node = data.get("id")
+        base = data.get("feebase", data.get("base"))
+        ppm = data.get("feeppm", data.get("ppm"))
+        if node and base is not None and ppm is not None:
+            return node, int(base), int(ppm)
+
+    cleaned = payload.replace('\\"', '"')
+    id_m = ID_RE.search(cleaned)
+    base_m = FEEBASE_RE.search(cleaned) or BASE_RE.search(cleaned)
+    ppm_m = FEEPPM_RE.search(cleaned) or PPM_RE.search(cleaned)
+    if id_m and base_m and ppm_m:
+        return id_m.group(1), int(base_m.group(1)), int(ppm_m.group(1))
+    return None
+
+
+def ensure_schema(conn):
+    cur = conn.cursor()
+    cur.execute("PRAGMA foreign_keys = ON")
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS peers (
+            id INTEGER PRIMARY KEY,
+            node_id TEXT NOT NULL UNIQUE
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS fee_change_events (
+            id INTEGER PRIMARY KEY,
+            ts REAL NOT NULL,
+            peer_id INTEGER NOT NULL,
+            set_base INTEGER,
+            set_ppm INTEGER,
+            baseline_base INTEGER,
+            baseline_ppm INTEGER,
+            size_mult REAL,
+            size_total_peers INTEGER,
+            size_less_peers INTEGER,
+            balance_mult REAL,
+            balance_our_msat INTEGER,
+            balance_total_msat INTEGER,
+            price_level INTEGER,
+            price_mult REAL,
+            mult_product REAL,
+            est_base INTEGER,
+            est_ppm INTEGER,
+            dedupe_hash TEXT NOT NULL,
+            FOREIGN KEY(peer_id) REFERENCES peers(id)
+        )
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS fee_change_events_unique
+        ON fee_change_events(peer_id, ts, dedupe_hash)
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS fee_change_events_peer_ts_idx
+        ON fee_change_events(peer_id, ts)
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS fee_change_events_ts_peer_idx
+        ON fee_change_events(ts, peer_id)
+        """
+    )
+    conn.commit()
+
+
+def update_state(state, peer, key, value):
+    if peer not in state:
+        state[peer] = {}
+    state[peer][key] = value
+
+
+def compute_estimate(state, peer):
+    s = state.get(peer, {})
+    base = s.get("baseline_base")
+    ppm = s.get("baseline_ppm")
+    if base is None or ppm is None:
+        return None
+
+    size_mult = s.get("size_mult")
+    balance_mult = s.get("balance_mult")
+    price_mult = s.get("price_mult")
+    if size_mult is None or balance_mult is None or price_mult is None:
+        return {
+            "mult_product": None,
+            "est_base": None,
+            "est_ppm": None,
+        }
+
+    mult_product = size_mult * balance_mult * price_mult
+    est_base = int(round(base * mult_product))
+    est_ppm = int(round(ppm * mult_product))
+    if est_ppm == 0:
+        est_ppm = 1
+
+    return {
+        "mult_product": mult_product,
+        "est_base": est_base,
+        "est_ppm": est_ppm,
+    }
+
+
+def build_dedupe_hash(ts, peer_id, snapshot):
+    fields = [
+        str(ts),
+        str(peer_id),
+        str(snapshot["set_base"]),
+        str(snapshot["set_ppm"]),
+        str(snapshot["baseline_base"]),
+        str(snapshot["baseline_ppm"]),
+        str(snapshot["size_mult"]),
+        str(snapshot["size_total_peers"]),
+        str(snapshot["size_less_peers"]),
+        str(snapshot["balance_mult"]),
+        str(snapshot["balance_our_msat"]),
+        str(snapshot["balance_total_msat"]),
+        str(snapshot["price_level"]),
+        str(snapshot["price_mult"]),
+        str(snapshot["mult_product"]),
+        str(snapshot["est_base"]),
+        str(snapshot["est_ppm"]),
+    ]
+    payload = "|".join(fields)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class Output:
+    def __init__(self, conn=None, commit_interval_seconds=60):
+        self.conn = conn
+        self.cur = conn.cursor() if conn else None
+        self.commit_interval_seconds = commit_interval_seconds
+        self.last_commit = time.monotonic() if conn else None
+        self.peer_cache = {}
+        self.pending_writes = False
+
+    def commit(self):
+        if self.conn:
+            self.conn.commit()
+            self.last_commit = time.monotonic()
+            self.pending_writes = False
+
+    def maybe_commit(self):
+        if not self.conn:
+            return
+        if not self.pending_writes:
+            return
+        if self.commit_interval_seconds is None:
+            return
+        elapsed = time.monotonic() - self.last_commit
+        if elapsed >= self.commit_interval_seconds:
+            self.commit()
+
+    def get_peer_id(self, peer):
+        if peer in self.peer_cache:
+            return self.peer_cache[peer]
+        self.cur.execute(
+            "INSERT OR IGNORE INTO peers (node_id) VALUES (?)",
+            (peer,),
+        )
+        self.cur.execute("SELECT id FROM peers WHERE node_id = ?", (peer,))
+        row = self.cur.fetchone()
+        peer_id = row[0]
+        self.peer_cache[peer] = peer_id
+        return peer_id
+
+    def insert_fee_change(self, ts, peer, snapshot):
+        if self.cur:
+            peer_id = self.get_peer_id(peer)
+            dedupe_hash = build_dedupe_hash(ts, peer_id, snapshot)
+            self.cur.execute(
+                """
+                INSERT OR IGNORE INTO fee_change_events (
+                    ts, peer_id, set_base, set_ppm, baseline_base, baseline_ppm,
+                    size_mult, size_total_peers, size_less_peers, balance_mult,
+                    balance_our_msat, balance_total_msat,
+                    price_level, price_mult, mult_product, est_base, est_ppm,
+                    dedupe_hash
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    ts,
+                    peer_id,
+                    snapshot["set_base"],
+                    snapshot["set_ppm"],
+                    snapshot["baseline_base"],
+                    snapshot["baseline_ppm"],
+                    snapshot["size_mult"],
+                    snapshot["size_total_peers"],
+                    snapshot["size_less_peers"],
+                    snapshot["balance_mult"],
+                    snapshot["balance_our_msat"],
+                    snapshot["balance_total_msat"],
+                    snapshot["price_level"],
+                    snapshot["price_mult"],
+                    snapshot["mult_product"],
+                    snapshot["est_base"],
+                    snapshot["est_ppm"],
+                    dedupe_hash,
+                ),
+            )
+            self.pending_writes = True
+            self.maybe_commit()
+        else:
+            sys.stdout.write(
+                "{ts},{peer},{set_base},{set_ppm},{baseline_base},{baseline_ppm},"
+                "{size_mult},{size_total_peers},{size_less_peers},{balance_mult},"
+                "{balance_our_msat},{balance_total_msat},{price_level},"
+                "{price_mult},{mult_product},{est_base},{est_ppm}\n".format(
+                    ts=ts,
+                    peer=peer,
+                    set_base=snapshot["set_base"],
+                    set_ppm=snapshot["set_ppm"],
+                    baseline_base=snapshot["baseline_base"],
+                    baseline_ppm=snapshot["baseline_ppm"],
+                    size_mult=snapshot["size_mult"],
+                    size_total_peers=snapshot["size_total_peers"],
+                    size_less_peers=snapshot["size_less_peers"],
+                    balance_mult=snapshot["balance_mult"],
+                    balance_our_msat=snapshot["balance_our_msat"],
+                    balance_total_msat=snapshot["balance_total_msat"],
+                    price_level=snapshot["price_level"],
+                    price_mult=snapshot["price_mult"],
+                    mult_product=snapshot["mult_product"],
+                    est_base=snapshot["est_base"],
+                    est_ppm=snapshot["est_ppm"],
+                )
+            )
+
+
+def extract_events_from_msg(msg):
+    m = SETCHANNEL_RE.match(msg) or SETCHANNELFEE_RE.match(msg)
+    if m:
+        payload = m.group(1)
+        parsed_payload = parse_setchannel_payload(payload)
+        if parsed_payload:
+            peer, base, ppm = parsed_payload
+            return [("setchannel", (peer, base, ppm))]
+        return []
+
+    m = BASELINE_RE.search(msg)
+    if m:
+        entries = BASELINE_ENTRY_RE.findall(m.group(1))
+        if entries:
+            return [("baseline", entries)]
+        return []
+
+    m = SIZE_RE.search(msg)
+    if m:
+        peer, total_s, less_s, more_s, mult_s = m.groups()
+        total = int(total_s)
+        less = int(less_s)
+        more = int(more_s)
+        if total == less + more:
+            mult = float(mult_s)
+            return [("size", (peer, total, less, mult))]
+        return []
+
+    m = BALANCE_MOVED_RE.search(msg)
+    if m:
+        peer = m.group(1)
+        to_us = int(m.group(5))
+        total = int(m.group(6))
+        mult = float(m.group(7))
+        return [("balance", (peer, mult, to_us, total))]
+
+    m = BALANCE_SET_RE.search(msg)
+    if m:
+        peer = m.group(1)
+        to_us = int(m.group(4))
+        total = int(m.group(5))
+        mult = float(m.group(6))
+        return [("balance", (peer, mult, to_us, total))]
+
+    m = PRICE_RE.search(msg)
+    if m:
+        peer, level_s, mult_s = m.groups()
+        level = int(level_s)
+        mult = float(mult_s)
+        return [("price", (peer, level, mult))]
+
+    return []
+
+
+def apply_event(ts, kind, data, state, output):
+    if kind == "baseline":
+        for peer, base_s, ppm_s in data:
+            base = int(base_s)
+            ppm = int(ppm_s)
+            update_state(state, peer, "baseline_base", base)
+            update_state(state, peer, "baseline_ppm", ppm)
+        return
+
+    if kind == "size":
+        peer, total, less, mult = data
+        update_state(state, peer, "size_mult", mult)
+        update_state(state, peer, "size_total_peers", total)
+        update_state(state, peer, "size_less_peers", less)
+        return
+
+    if kind == "balance":
+        peer, mult, to_us, total = data
+        update_state(state, peer, "balance_mult", mult)
+        update_state(state, peer, "balance_our_msat", to_us)
+        update_state(state, peer, "balance_total_msat", total)
+        return
+
+    if kind == "price":
+        peer, level, mult = data
+        update_state(state, peer, "price_level", level)
+        update_state(state, peer, "price_mult", mult)
+        return
+
+    if kind == "setchannel":
+        peer, set_base, set_ppm = data
+        est = compute_estimate(state, peer)
+        snapshot = {
+            "set_base": set_base,
+            "set_ppm": set_ppm,
+            "baseline_base": state.get(peer, {}).get("baseline_base"),
+            "baseline_ppm": state.get(peer, {}).get("baseline_ppm"),
+            "size_mult": state.get(peer, {}).get("size_mult"),
+            "size_total_peers": state.get(peer, {}).get("size_total_peers"),
+            "size_less_peers": state.get(peer, {}).get("size_less_peers"),
+            "balance_mult": state.get(peer, {}).get("balance_mult"),
+            "balance_our_msat": state.get(peer, {}).get("balance_our_msat"),
+            "balance_total_msat": state.get(peer, {}).get("balance_total_msat"),
+            "price_level": state.get(peer, {}).get("price_level"),
+            "price_mult": state.get(peer, {}).get("price_mult"),
+            "mult_product": est.get("mult_product") if est else None,
+            "est_base": est.get("est_base") if est else None,
+            "est_ppm": est.get("est_ppm") if est else None,
+        }
+        output.insert_fee_change(ts, peer, snapshot)
+
+
+def process_stream(lines, output):
+    state = {}
+    for line in lines:
+        parsed = parse_line(line)
+        if parsed:
+            ts, msg, _ = parsed
+            for kind, data in extract_events_from_msg(msg):
+                apply_event(ts, kind, data, state, output)
+        output.maybe_commit()
+    output.commit()
+
+
+def open_lines(paths):
+    if not paths:
+        for line in sys.stdin:
+            yield line
+        return
+
+    for path in paths:
+        if os.path.isdir(path):
+            for root, _, files in os.walk(path):
+                for name in files:
+                    full = os.path.join(root, name)
+                    with open(full, "r", encoding="utf-8", errors="replace") as f:
+                        for line in f:
+                            yield line
+        else:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    yield line
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse CLBOSS fee-setting logs into sqlite."
+    )
+    parser.add_argument(
+        "--db",
+        help="Path to sqlite database (created if missing).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Log files or directories (reads stdin if omitted).",
+    )
+    parser.add_argument(
+        "--commit-seconds",
+        type=float,
+        default=60,
+        help="Commit database writes every N seconds (default: 60).",
+    )
+    args = parser.parse_args()
+
+    if args.db:
+        conn = sqlite3.connect(args.db)
+        ensure_schema(conn)
+        output = Output(conn=conn, commit_interval_seconds=args.commit_seconds)
+        process_stream(open_lines(args.paths), output)
+        conn.close()
+        return
+
+    sys.stdout.write(
+        "ts,peer,set_base,set_ppm,baseline_base,baseline_ppm,size_mult,"
+        "size_total_peers,size_less_peers,balance_mult,balance_our_msat,"
+        "balance_total_msat,price_level,price_mult,mult_product,est_base,"
+        "est_ppm\n"
+    )
+    output = Output()
+    process_stream(open_lines(args.paths), output)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/plot-aggregate
+++ b/contrib/plot-aggregate
@@ -1,0 +1,1121 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import math
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+BUCKET_SECONDS = 24 * 60 * 60
+EARNINGS_SYMLOG_LINTHRESH = 1.0
+EARNINGS_SYMLOG_LINSCALE = 0.3
+FEE_SYMLOG_LINTHRESH = 1.0
+FEE_SYMLOG_LINSCALE = 0.3
+
+
+def local_tz():
+    return datetime.now().astimezone().tzinfo
+
+
+def normalize_dt(dt):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=local_tz())
+    return dt.astimezone(timezone.utc)
+
+
+def parse_ts_iso(ts):
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return normalize_dt(datetime.fromisoformat(ts))
+
+
+def parse_ts_epoch(ts):
+    if isinstance(ts, (int, float)):
+        return datetime.fromtimestamp(ts, timezone.utc)
+    try:
+        return datetime.fromtimestamp(float(ts), timezone.utc)
+    except (TypeError, ValueError):
+        return parse_ts_iso(ts)
+
+
+def parse_ts(ts):
+    return parse_ts_epoch(ts)
+
+
+def parse_time_arg(value):
+    if value is None:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    if re.match(r"^[0-9]{4}-[0-9]{2}$", value):
+        return normalize_dt(datetime.fromisoformat(f"{value}-01T00:00:00"))
+    if re.match(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$", value):
+        return normalize_dt(datetime.fromisoformat(f"{value}T00:00:00"))
+    rel = re.match(r"^([+-]?)(\d+)([smhdw])$", value)
+    if rel:
+        sign, num_s, unit = rel.groups()
+        num = int(num_s)
+        delta = {
+            "s": timedelta(seconds=num),
+            "m": timedelta(minutes=num),
+            "h": timedelta(hours=num),
+            "d": timedelta(days=num),
+            "w": timedelta(weeks=num),
+        }[unit]
+        if sign == "-":
+            delta = -delta
+        return normalize_dt(datetime.now() + delta)
+    if value.count(":") in (1, 2) and "T" not in value and "-" not in value:
+        today = datetime.now().date().isoformat()
+        return normalize_dt(datetime.fromisoformat(f"{today}T{value}"))
+    return normalize_dt(datetime.fromisoformat(value))
+
+
+def price_level_to_mult(level):
+    try:
+        import numpy as np
+    except ImportError:
+        if isinstance(level, (int, float)):
+            if level < 0:
+                return math.pow(0.8, -level)
+            if level > 0:
+                return math.pow(1.2, level)
+            return 1.0
+        return [price_level_to_mult(v) for v in level]
+
+    arr = np.asarray(level, dtype=float)
+    mult = np.where(
+        arr < 0,
+        np.power(0.8, -arr),
+        np.where(arr > 0, np.power(1.2, arr), 1.0),
+    )
+    if np.isscalar(level):
+        return float(mult)
+    return mult
+
+
+def price_mult_to_level(mult):
+    try:
+        import numpy as np
+    except ImportError:
+        if isinstance(mult, (int, float)):
+            if mult < 1:
+                return -math.log(mult) / math.log(0.8)
+            if mult > 1:
+                return math.log(mult) / math.log(1.2)
+            return 0.0
+        return [price_mult_to_level(v) for v in mult]
+
+    arr = np.asarray(mult, dtype=float)
+    level = np.zeros_like(arr, dtype=float)
+    lt_one = (arr > 0) & (arr < 1)
+    gt_one = arr > 1
+    if np.any(lt_one):
+        level[lt_one] = -np.log(arr[lt_one]) / np.log(0.8)
+    if np.any(gt_one):
+        level[gt_one] = np.log(arr[gt_one]) / np.log(1.2)
+    if np.isscalar(mult):
+        return float(level)
+    return level
+
+
+def format_mult_tick(value):
+    if value == 0:
+        return "0"
+    if value < 1:
+        nice_values = [
+            (0.5, "0.5"),
+            (0.2, "0.2"),
+            (0.1, "0.10"),
+            (0.05, "0.05"),
+            (0.02, "0.02"),
+            (0.01, "0.01"),
+        ]
+        for target, label in nice_values:
+            if abs(value - target) / target <= 0.08:
+                return label
+    abs_val = abs(value)
+    for decimals in (0, 1, 2):
+        rounded = round(value, decimals)
+        if rounded != 0 and abs(value - rounded) / abs_val < 0.01:
+            if decimals == 0:
+                return str(int(round(rounded)))
+            text = f"{rounded:.{decimals}f}"
+            return text.rstrip("0").rstrip(".")
+    return f"{value:.3g}"
+
+
+def nice_mult_ticks(vmin, vmax):
+    if vmin <= 0 or vmax <= 0:
+        return []
+    if vmin > vmax:
+        vmin, vmax = vmax, vmin
+    exp_min = int(math.floor(math.log10(vmin)))
+    exp_max = int(math.ceil(math.log10(vmax)))
+    mantissas = [1, 2, 5]
+    ticks = []
+    for exp in range(exp_min, exp_max + 1):
+        base = 10 ** exp
+        for m in mantissas:
+            value = m * base
+            if vmin <= value <= vmax:
+                ticks.append(value)
+    if not ticks:
+        if vmin == vmax:
+            return [vmin]
+        return [vmin, vmax]
+    return ticks
+
+
+def set_log_ylim(ax, values, pad_frac=0.2, min_floor=0.9, min_top=10):
+    if not values:
+        return
+    max_val = max(values)
+    if max_val < min_floor:
+        max_val = min_floor
+    top = max(max_val * (1.0 + pad_frac), min_top)
+    bottom = min_floor
+    ax.set_ylim(bottom=bottom, top=top)
+
+
+def set_log_decade_ticks(ax):
+    ymin, ymax = ax.get_ylim()
+    if ymin <= 0 or ymax <= 0:
+        return
+    exp_min = int(math.floor(math.log10(ymin)))
+    exp_max = int(math.ceil(math.log10(ymax)))
+    ticks = [10 ** e for e in range(exp_min, exp_max + 1) if 10 ** e >= 1]
+    labels = [str(int(t)) for t in ticks]
+    ax.set_yticks(ticks)
+    ax.set_yticklabels(labels)
+
+
+def set_log_ylim_with_floor(ax, values, floor, min_top, pad_frac=0.05):
+    if not values:
+        return
+    max_val = max(values)
+    top = max(max_val * (1.0 + pad_frac), min_top)
+    bottom = floor / (1.0 + pad_frac)
+    ax.set_ylim(bottom=bottom, top=top)
+
+
+def set_linear_ylim(ax, values, pad_frac=0.1, min_pad=1.0):
+    if not values:
+        return
+    vmin = min(values)
+    vmax = max(values)
+    if vmin == vmax:
+        pad = max(abs(vmin) * pad_frac, min_pad)
+    else:
+        pad = (vmax - vmin) * pad_frac
+    ax.set_ylim(bottom=vmin - pad, top=vmax + pad)
+
+
+def set_symlog_ylim(ax, values, clamp_zero=False, pad_frac=0.1, min_pad=1.0):
+    if not values:
+        return
+    vmin = min(values)
+    vmax = max(values)
+    if vmin == vmax:
+        pad = max(abs(vmin) * pad_frac, min_pad)
+    else:
+        pad = (vmax - vmin) * pad_frac
+    bottom = vmin - pad
+    top = vmax + pad
+    if clamp_zero and bottom < 0:
+        bottom = 0
+    ax.set_ylim(bottom=bottom, top=top)
+
+
+def set_symlog_ticks(ax, linthresh, symmetric=True):
+    ymin, ymax = ax.get_ylim()
+    max_abs = max(abs(ymin), abs(ymax))
+    if max_abs <= 0:
+        ax.set_yticks([0])
+        ax.set_yticklabels(["0"])
+        return
+    max_exp = int(math.floor(math.log10(max_abs)))
+    ticks = [0.0]
+    for exp in range(0, max_exp + 1):
+        tick = 10 ** exp
+        if tick < linthresh or tick > max_abs:
+            continue
+        if symmetric:
+            ticks.extend([-tick, tick])
+        else:
+            ticks.append(tick)
+    ticks = sorted(set(ticks))
+    labels = []
+    for tick in ticks:
+        if tick == 0:
+            labels.append("0")
+        else:
+            labels.append(str(int(tick)))
+    ax.set_yticks(ticks)
+    ax.set_yticklabels(labels)
+
+
+def percentile_from_sorted(values, q):
+    if not values:
+        return None
+    if q <= 0:
+        return values[0]
+    if q >= 1:
+        return values[-1]
+    pos = q * (len(values) - 1)
+    low = int(math.floor(pos))
+    high = int(math.ceil(pos))
+    if low == high:
+        return values[low]
+    weight = pos - low
+    return values[low] + (values[high] - values[low]) * weight
+
+
+def add_common_args(parser):
+    parser.add_argument(
+        "--db",
+        default=os.path.expanduser("./clboss-fee-info.sqlite3"),
+        help="Path to sqlite database.",
+    )
+    parser.add_argument(
+        "--png",
+        nargs="?",
+        const="__DEFAULT__",
+        default=None,
+        help="Output image path.",
+    )
+    parser.add_argument(
+        "--csv",
+        nargs="?",
+        const="__DEFAULT__",
+        default=None,
+        help="Output CSV path.",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Show the plot interactively.",
+    )
+    parser.add_argument(
+        "--since",
+        dest="from_ts",
+        default=None,
+        help="Start time (ISO-8601 or HH:MM[:SS]).",
+    )
+    parser.add_argument(
+        "--before",
+        dest="to_ts",
+        default=None,
+        help="End time (ISO-8601 or HH:MM[:SS]).",
+    )
+
+
+def add_lightning_args(parser):
+    parser.add_argument("--mainnet", action="store_true", help="Run on mainnet")
+    parser.add_argument("--testnet", action="store_true", help="Run on testnet")
+    parser.add_argument("--signet", action="store_true", help="Run on signet")
+    parser.add_argument("--regtest", action="store_true", help="Run on regtest")
+    parser.add_argument("--network", help="Set the network explicitly")
+    parser.add_argument("--lightning-dir", help="lightning data location")
+
+
+def resolve_network_option(args):
+    if args.network:
+        return f"--network={args.network}"
+    if args.testnet:
+        return "--network=testnet"
+    if args.signet:
+        return "--network=signet"
+    if args.regtest:
+        return "--network=regtest"
+    return "--network=bitcoin"
+
+
+def resolve_lightning_dir(args):
+    if args.lightning_dir:
+        if not os.path.isdir(args.lightning_dir):
+            raise ValueError(f'"{args.lightning_dir}" is not a valid directory')
+        return args.lightning_dir
+    return None
+
+
+def run_lightning_cli_command(lightning_dir, network_option, subcommand, *args):
+    try:
+        command = ["lightning-cli", network_option, subcommand, *args]
+        if lightning_dir:
+            command = command[:2] \
+                + [f"--lightning-dir={lightning_dir}"] \
+                + command[2:]
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Command '{command}' failed with error: {e}", file=sys.stderr)
+    except FileNotFoundError:
+        print("lightning-cli not found in PATH.", file=sys.stderr)
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse JSON from command '{command}': {e}", file=sys.stderr)
+    return None
+
+
+def get_out_path(args, suffix):
+    if args.png is None:
+        return None
+    if args.png == "__DEFAULT__":
+        return f"aggregate-{suffix}.png"
+    return args.png
+
+
+def get_csv_path(args, suffix):
+    if args.csv is None:
+        return None
+    if args.csv == "__DEFAULT__":
+        return f"aggregate-{suffix}.csv"
+    return args.csv
+
+
+def write_csv(args, rows, suffix):
+    path = get_csv_path(args, suffix)
+    if not path:
+        return
+    headers = [
+        "bucket_time",
+        "p00",
+        "p10",
+        "p25",
+        "p50",
+        "p75",
+        "p90",
+        "p100",
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+        writer.writerows(rows)
+
+
+def fetch_field_values(db, from_ts, to_ts, field):
+    query = (
+        f"SELECT f.ts, f.{field}, p.node_id "
+        "FROM fee_change_events f "
+        "JOIN peers p ON p.id = f.peer_id "
+        f"WHERE f.{field} IS NOT NULL"
+    )
+    params = []
+    if from_ts:
+        query += " AND f.ts >= ?"
+        params.append(from_ts.timestamp())
+    if to_ts:
+        query += " AND f.ts <= ?"
+        params.append(to_ts.timestamp())
+    query += " ORDER BY f.ts"
+
+    with sqlite3.connect(db) as conn:
+        return conn.execute(query, params).fetchall()
+
+
+def bucket_latest_by_node(rows):
+    buckets = {}
+    for ts, value, node_id in rows:
+        bucket = math.floor(ts / BUCKET_SECONDS) * BUCKET_SECONDS
+        bucket_nodes = buckets.setdefault(bucket, {})
+        # Keep the latest value per node in each bucket.
+        bucket_nodes[node_id] = value
+    return buckets
+
+
+def compute_percentile_series(buckets, percentiles):
+    series = []
+    for bucket in sorted(buckets):
+        values = sorted(buckets[bucket].values())
+        if not values:
+            continue
+        row = [bucket]
+        for q in percentiles:
+            row.append(percentile_from_sorted(values, q))
+        series.append(row)
+    return series
+
+
+def get_percentile_series(db, from_ts, to_ts, field):
+    rows = fetch_field_values(db, from_ts, to_ts, field)
+    buckets = bucket_latest_by_node(rows)
+    percentiles = [0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0]
+    labels = ["p00", "p10", "p25", "p50", "p75", "p90", "p100"]
+    series = compute_percentile_series(buckets, percentiles)
+    return series, percentiles, labels
+
+
+def filter_earnings_history(history, from_ts, to_ts):
+    filtered = []
+    for entry in history:
+        bucket_time = entry.get("bucket_time")
+        if not bucket_time or bucket_time <= 0:
+            continue
+        ts = parse_ts_epoch(bucket_time)
+        if from_ts and ts < from_ts:
+            continue
+        if to_ts and ts > to_ts:
+            continue
+        filtered.append(entry)
+    return filtered
+
+
+def fetch_earnings_history(args):
+    if shutil.which("lightning-cli") is None:
+        print("warning: lightning-cli not found; skipping earnings data", file=sys.stderr)
+        return []
+
+    network_option = resolve_network_option(args)
+    lightning_dir = resolve_lightning_dir(args)
+    data = run_lightning_cli_command(
+        lightning_dir, network_option, "clboss-earnings-history", "all"
+    )
+    if not data or "history" not in data:
+        print("warning: earnings data unavailable; skipping earnings data", file=sys.stderr)
+        return []
+    return data["history"]
+
+
+def get_earnings_percentile_series(args):
+    percentiles = [0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0]
+    labels = ["p00", "p10", "p25", "p50", "p75", "p90", "p100"]
+
+    history = fetch_earnings_history(args)
+    if not history:
+        return [], percentiles, labels
+    if "node" not in history[0]:
+        print(
+            "warning: clboss-earnings-history did not return per-node entries; "
+            "update clboss to use nodeid=all",
+            file=sys.stderr,
+        )
+        return [], percentiles, labels
+    history = filter_earnings_history(history, args.from_ts, args.to_ts)
+    if not history:
+        return [], percentiles, labels
+
+    buckets = {}
+    nodes = set()
+    for entry in history:
+        bucket_time = entry.get("bucket_time")
+        node = entry.get("node")
+        if not bucket_time or not node:
+            continue
+        in_earnings = entry.get("in_earnings", 0)
+        out_earnings = entry.get("out_earnings", 0)
+        in_expenditures = entry.get("in_expenditures", 0)
+        out_expenditures = entry.get("out_expenditures", 0)
+        net_msat = (in_earnings + out_earnings) - (in_expenditures + out_expenditures)
+        buckets.setdefault(bucket_time, {})[node] = net_msat
+        nodes.add(node)
+
+    if not buckets or not nodes:
+        return [], percentiles, labels
+
+    nodes = sorted(nodes)
+    series = []
+    for bucket in sorted(buckets):
+        values = []
+        bucket_nodes = buckets[bucket]
+        for node in nodes:
+            values.append(bucket_nodes.get(node, 0) / 1000.0)
+        values.sort()
+        row = [bucket]
+        for q in percentiles:
+            row.append(percentile_from_sorted(values, q))
+        series.append(row)
+
+    return series, percentiles, labels
+
+
+def split_percentile_series(series, percentiles):
+    ts = [parse_ts_epoch(row[0]) for row in series]
+    percentile_series = []
+    for idx in range(1, len(percentiles) + 1):
+        percentile_series.append([row[idx] for row in series])
+    return ts, percentile_series
+
+
+def adjust_log_series(percentile_series, floor=1):
+    adjusted = []
+    all_values = []
+    for series in percentile_series:
+        converted = [value if value > floor else floor for value in series]
+        adjusted.append(converted)
+        all_values.extend(converted)
+    return adjusted, all_values
+
+
+def add_percentile_lines(ax, ts, percentile_series, labels):
+    lines = []
+    for label, values in zip(labels, percentile_series):
+        line, = ax.plot(ts, values, linewidth=1.5, label=label)
+        lines.append(line)
+    legend_lines = list(reversed(lines))
+    legend_labels = list(reversed(labels))
+    ax.legend(legend_lines, legend_labels)
+
+
+def move_yaxis_right(ax):
+    ax.yaxis.set_label_position("right")
+    ax.yaxis.tick_right()
+
+
+def plot_price_level(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    series, percentiles, labels = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "price_level"
+    )
+    if not series:
+        raise SystemExit("no theory_level data in time range")
+
+    ts, percentile_series = split_percentile_series(series, percentiles)
+
+    fig, ax = plt.subplots(figsize=(12, 4))
+    add_percentile_lines(ax, ts, percentile_series, labels)
+    ax.set_ylabel("theory_level")
+    ax.set_title("theory_level percentiles")
+
+    ax_mult = ax.secondary_yaxis(
+        "right",
+        functions=(price_level_to_mult, price_mult_to_level),
+    )
+    ax_mult.set_ylabel("theory_mult")
+
+    min_level = min(percentile_series[0])
+    max_level = max(percentile_series[-1])
+    mult_min = price_level_to_mult(min_level)
+    mult_max = price_level_to_mult(max_level)
+    mult_ticks = nice_mult_ticks(mult_min, mult_max)
+    if mult_ticks:
+        ax_mult.set_yticks(mult_ticks)
+        ax_mult.set_yticklabels([format_mult_tick(v) for v in mult_ticks])
+
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "theory")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, series, "theory")
+
+
+def plot_baseline_base(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    series, percentiles, labels = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "baseline_base"
+    )
+    if not series:
+        raise SystemExit("no baseline_base data in time range")
+
+    ts, percentile_series = split_percentile_series(series, percentiles)
+    fig, ax = plt.subplots(figsize=(12, 4))
+    add_percentile_lines(ax, ts, percentile_series, labels)
+    ax.set_ylabel("baseline_base")
+    ax.set_title("baseline_base percentiles")
+    ax.set_yscale(
+        "symlog",
+        linthresh=FEE_SYMLOG_LINTHRESH,
+        linscale=FEE_SYMLOG_LINSCALE,
+    )
+    values = [value for band in percentile_series for value in band]
+    min_val = min(values)
+    set_symlog_ylim(ax, values, clamp_zero=min_val >= 0)
+    set_symlog_ticks(ax, FEE_SYMLOG_LINTHRESH, symmetric=min_val < 0)
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "baseline-base")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, series, "baseline-base")
+
+
+def plot_baseline_ppm(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    series, percentiles, labels = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "baseline_ppm"
+    )
+    if not series:
+        raise SystemExit("no baseline_ppm data in time range")
+
+    ts, percentile_series = split_percentile_series(series, percentiles)
+    fig, ax = plt.subplots(figsize=(12, 4))
+    add_percentile_lines(ax, ts, percentile_series, labels)
+    ax.set_ylabel("baseline_ppm")
+    ax.set_title("baseline_ppm percentiles")
+    ax.set_yscale(
+        "symlog",
+        linthresh=FEE_SYMLOG_LINTHRESH,
+        linscale=FEE_SYMLOG_LINSCALE,
+    )
+    values = [value for band in percentile_series for value in band]
+    min_val = min(values)
+    set_symlog_ylim(ax, values, clamp_zero=min_val >= 0)
+    set_symlog_ticks(ax, FEE_SYMLOG_LINTHRESH, symmetric=min_val < 0)
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "baseline-ppm")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, series, "baseline-ppm")
+
+
+def plot_size_mult(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    series, percentiles, labels = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "size_mult"
+    )
+    if not series:
+        raise SystemExit("no size_mult data in time range")
+
+    ts, percentile_series = split_percentile_series(series, percentiles)
+    percentile_series, values = adjust_log_series(percentile_series, floor=0.5)
+    fig, ax = plt.subplots(figsize=(12, 4))
+    add_percentile_lines(ax, ts, percentile_series, labels)
+    ax.set_ylabel("size_mult")
+    ax.set_title("size_mult percentiles")
+    ax.set_yscale("log")
+    move_yaxis_right(ax)
+    set_log_ylim_with_floor(ax, values, floor=0.5, min_top=16)
+    ax.set_yticks(
+        [0.5, 1, 2, 4, 8, 16],
+        ["1/2", "1", "2", "4", "8", "16"],
+    )
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "size")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, series, "size")
+
+
+def plot_balance_mult(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    series, percentiles, labels = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "balance_mult"
+    )
+    if not series:
+        raise SystemExit("no balance_mult data in time range")
+
+    ts, percentile_series = split_percentile_series(series, percentiles)
+    percentile_series, values = adjust_log_series(percentile_series, floor=1 / 6)
+    fig, ax = plt.subplots(figsize=(12, 4))
+    add_percentile_lines(ax, ts, percentile_series, labels)
+    ax.set_ylabel("balance_mult")
+    ax.set_title("balance_mult percentiles")
+    ax.set_yscale("log")
+    move_yaxis_right(ax)
+    set_log_ylim_with_floor(ax, values, floor=1 / 6, min_top=6)
+    ax.set_yticks(
+        [1 / 6, 1 / 3, 1, 3, 6],
+        ["1/6", "1/3", "1", "3", "6"],
+    )
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "balance")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, series, "balance")
+
+
+def plot_set_base(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    series, percentiles, labels = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "set_base"
+    )
+    if not series:
+        raise SystemExit("no advertised_base data in time range")
+
+    ts, percentile_series = split_percentile_series(series, percentiles)
+    fig, ax = plt.subplots(figsize=(12, 4))
+    add_percentile_lines(ax, ts, percentile_series, labels)
+    ax.set_ylabel("advertised_base")
+    ax.set_title("advertised_base percentiles")
+    ax.set_yscale(
+        "symlog",
+        linthresh=FEE_SYMLOG_LINTHRESH,
+        linscale=FEE_SYMLOG_LINSCALE,
+    )
+    values = [value for band in percentile_series for value in band]
+    min_val = min(values)
+    set_symlog_ylim(ax, values, clamp_zero=min_val >= 0)
+    set_symlog_ticks(ax, FEE_SYMLOG_LINTHRESH, symmetric=min_val < 0)
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "advertised-base")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, series, "advertised-base")
+
+
+def plot_set_ppm(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    series, percentiles, labels = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "set_ppm"
+    )
+    if not series:
+        raise SystemExit("no advertised_ppm data in time range")
+
+    ts, percentile_series = split_percentile_series(series, percentiles)
+    fig, ax = plt.subplots(figsize=(12, 4))
+    add_percentile_lines(ax, ts, percentile_series, labels)
+    ax.set_ylabel("advertised_ppm")
+    ax.set_title("advertised_ppm percentiles")
+    ax.set_yscale(
+        "symlog",
+        linthresh=FEE_SYMLOG_LINTHRESH,
+        linscale=FEE_SYMLOG_LINSCALE,
+    )
+    values = [value for band in percentile_series for value in band]
+    min_val = min(values)
+    set_symlog_ylim(ax, values, clamp_zero=min_val >= 0)
+    set_symlog_ticks(ax, FEE_SYMLOG_LINTHRESH, symmetric=min_val < 0)
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "advertised-ppm")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, series, "advertised-ppm")
+
+
+def plot_earnings(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    series, percentiles, labels = get_earnings_percentile_series(args)
+    if not series:
+        raise SystemExit("no earnings data in time range")
+
+    ts, percentile_series = split_percentile_series(series, percentiles)
+    fig, ax = plt.subplots(figsize=(12, 4))
+    add_percentile_lines(ax, ts, percentile_series, labels)
+    ax.set_ylabel("daily net earnings (sat/day)")
+    ax.set_title("daily net earnings percentiles")
+    ax.set_yscale(
+        "symlog",
+        linthresh=EARNINGS_SYMLOG_LINTHRESH,
+        linscale=EARNINGS_SYMLOG_LINSCALE,
+    )
+    ax.axhline(0, color="black", linewidth=0.8, alpha=0.4)
+    values = [0.0] + [value for band in percentile_series for value in band]
+    set_linear_ylim(ax, values)
+    set_symlog_ticks(ax, EARNINGS_SYMLOG_LINTHRESH)
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "earnings")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, series, "earnings")
+
+
+def plot_combo(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    price_series, percentiles, labels = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "price_level"
+    )
+    base_series, _, _ = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "baseline_base"
+    )
+    ppm_series, _, _ = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "baseline_ppm"
+    )
+    size_series, _, _ = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "size_mult"
+    )
+    balance_series, _, _ = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "balance_mult"
+    )
+    set_base_series, _, _ = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "set_base"
+    )
+    set_ppm_series, _, _ = get_percentile_series(
+        args.db, args.from_ts, args.to_ts, "set_ppm"
+    )
+    earnings_series, _, _ = get_earnings_percentile_series(args)
+    if (
+        not price_series
+        and not base_series
+        and not ppm_series
+        and not size_series
+        and not balance_series
+        and not set_base_series
+        and not set_ppm_series
+        and not earnings_series
+    ):
+        raise SystemExit("no aggregate data in time range")
+
+    fig, axes = plt.subplots(8, 1, figsize=(12, 24), sharex=True)
+    (
+        ax_base,
+        ax_ppm,
+        ax_size,
+        ax_balance,
+        ax_price,
+        ax_set_base,
+        ax_set_ppm,
+        ax_earnings,
+    ) = axes
+
+    if base_series:
+        ts, base_percentiles = split_percentile_series(base_series, percentiles)
+        add_percentile_lines(ax_base, ts, base_percentiles, labels)
+        ax_base.set_ylabel("baseline_base")
+        ax_base.set_title("baseline_base percentiles")
+        ax_base.set_yscale(
+            "symlog",
+            linthresh=FEE_SYMLOG_LINTHRESH,
+            linscale=FEE_SYMLOG_LINSCALE,
+        )
+        base_values = [value for band in base_percentiles for value in band]
+        min_val = min(base_values)
+        set_symlog_ylim(ax_base, base_values, clamp_zero=min_val >= 0)
+        set_symlog_ticks(ax_base, FEE_SYMLOG_LINTHRESH, symmetric=min_val < 0)
+    else:
+        ax_base.set_title("baseline_base percentiles (no data)")
+
+    if ppm_series:
+        ts, ppm_percentiles = split_percentile_series(ppm_series, percentiles)
+        add_percentile_lines(ax_ppm, ts, ppm_percentiles, labels)
+        ax_ppm.set_ylabel("baseline_ppm")
+        ax_ppm.set_title("baseline_ppm percentiles")
+        ax_ppm.set_yscale(
+            "symlog",
+            linthresh=FEE_SYMLOG_LINTHRESH,
+            linscale=FEE_SYMLOG_LINSCALE,
+        )
+        ppm_values = [value for band in ppm_percentiles for value in band]
+        min_val = min(ppm_values)
+        set_symlog_ylim(ax_ppm, ppm_values, clamp_zero=min_val >= 0)
+        set_symlog_ticks(ax_ppm, FEE_SYMLOG_LINTHRESH, symmetric=min_val < 0)
+    else:
+        ax_ppm.set_title("baseline_ppm percentiles (no data)")
+
+    if size_series:
+        ts, size_percentiles = split_percentile_series(size_series, percentiles)
+        size_percentiles, size_values = adjust_log_series(size_percentiles, floor=0.5)
+        add_percentile_lines(ax_size, ts, size_percentiles, labels)
+        ax_size.set_ylabel("size_mult")
+        ax_size.set_title("size_mult percentiles")
+        ax_size.set_yscale("log")
+        move_yaxis_right(ax_size)
+        set_log_ylim_with_floor(ax_size, size_values, floor=0.5, min_top=16)
+        ax_size.set_yticks(
+            [0.5, 1, 2, 4, 8, 16],
+            ["1/2", "1", "2", "4", "8", "16"],
+        )
+    else:
+        ax_size.set_title("size_mult percentiles (no data)")
+
+    if balance_series:
+        ts, balance_percentiles = split_percentile_series(balance_series, percentiles)
+        balance_percentiles, balance_values = adjust_log_series(balance_percentiles, floor=1 / 6)
+        add_percentile_lines(ax_balance, ts, balance_percentiles, labels)
+        ax_balance.set_ylabel("balance_mult")
+        ax_balance.set_title("balance_mult percentiles")
+        ax_balance.set_yscale("log")
+        move_yaxis_right(ax_balance)
+        set_log_ylim_with_floor(ax_balance, balance_values, floor=1 / 6, min_top=6)
+        ax_balance.set_yticks(
+            [1 / 6, 1 / 3, 1, 3, 6],
+            ["1/6", "1/3", "1", "3", "6"],
+        )
+    else:
+        ax_balance.set_title("balance_mult percentiles (no data)")
+
+    if price_series:
+        ts, price_percentiles = split_percentile_series(price_series, percentiles)
+        add_percentile_lines(ax_price, ts, price_percentiles, labels)
+        ax_price.set_ylabel("theory_level")
+        ax_price.set_title("theory_level percentiles")
+
+        ax_mult = ax_price.secondary_yaxis(
+            "right",
+            functions=(price_level_to_mult, price_mult_to_level),
+        )
+        ax_mult.set_ylabel("theory_mult")
+        min_level = min(price_percentiles[0])
+        max_level = max(price_percentiles[-1])
+        mult_min = price_level_to_mult(min_level)
+        mult_max = price_level_to_mult(max_level)
+        mult_ticks = nice_mult_ticks(mult_min, mult_max)
+        if mult_ticks:
+            ax_mult.set_yticks(mult_ticks)
+            ax_mult.set_yticklabels([format_mult_tick(v) for v in mult_ticks])
+    else:
+        ax_price.set_title("theory_level percentiles (no data)")
+
+    if set_base_series:
+        ts, set_base_percentiles = split_percentile_series(
+            set_base_series, percentiles
+        )
+        add_percentile_lines(ax_set_base, ts, set_base_percentiles, labels)
+        ax_set_base.set_ylabel("advertised_base")
+        ax_set_base.set_title("advertised_base percentiles")
+        ax_set_base.set_yscale(
+            "symlog",
+            linthresh=FEE_SYMLOG_LINTHRESH,
+            linscale=FEE_SYMLOG_LINSCALE,
+        )
+        set_base_values = [value for band in set_base_percentiles for value in band]
+        min_val = min(set_base_values)
+        set_symlog_ylim(ax_set_base, set_base_values, clamp_zero=min_val >= 0)
+        set_symlog_ticks(ax_set_base, FEE_SYMLOG_LINTHRESH, symmetric=min_val < 0)
+    else:
+        ax_set_base.set_title("advertised_base percentiles (no data)")
+
+    if set_ppm_series:
+        ts, set_ppm_percentiles = split_percentile_series(
+            set_ppm_series, percentiles
+        )
+        add_percentile_lines(ax_set_ppm, ts, set_ppm_percentiles, labels)
+        ax_set_ppm.set_ylabel("advertised_ppm")
+        ax_set_ppm.set_title("advertised_ppm percentiles")
+        ax_set_ppm.set_yscale(
+            "symlog",
+            linthresh=FEE_SYMLOG_LINTHRESH,
+            linscale=FEE_SYMLOG_LINSCALE,
+        )
+        set_ppm_values = [value for band in set_ppm_percentiles for value in band]
+        min_val = min(set_ppm_values)
+        set_symlog_ylim(ax_set_ppm, set_ppm_values, clamp_zero=min_val >= 0)
+        set_symlog_ticks(ax_set_ppm, FEE_SYMLOG_LINTHRESH, symmetric=min_val < 0)
+    else:
+        ax_set_ppm.set_title("advertised_ppm percentiles (no data)")
+
+    if earnings_series:
+        ts, earnings_percentiles = split_percentile_series(
+            earnings_series, percentiles
+        )
+        add_percentile_lines(ax_earnings, ts, earnings_percentiles, labels)
+        ax_earnings.set_ylabel("daily net earnings (sat/day)")
+        ax_earnings.set_title("daily net earnings percentiles")
+        ax_earnings.set_yscale(
+            "symlog",
+            linthresh=EARNINGS_SYMLOG_LINTHRESH,
+            linscale=EARNINGS_SYMLOG_LINSCALE,
+        )
+        ax_earnings.axhline(0, color="black", linewidth=0.8, alpha=0.4)
+        values = [0.0] + [value for band in earnings_percentiles for value in band]
+        set_linear_ylim(ax_earnings, values)
+        set_symlog_ticks(ax_earnings, EARNINGS_SYMLOG_LINTHRESH)
+    else:
+        ax_earnings.set_title("daily net earnings percentiles (no data)")
+
+    fig.tight_layout()
+
+    out_path = get_out_path(args, "combo")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot aggregated fee statistics from clboss fee logs."
+    )
+    parser.add_argument(
+        "--view",
+        required=True,
+        choices=[
+            "theory",
+            "baseline-base",
+            "baseline-ppm",
+            "size",
+            "balance",
+            "advertised-base",
+            "advertised-ppm",
+            "earnings",
+            "combo",
+        ],
+        help="Aggregate view to render.",
+    )
+    add_common_args(parser)
+    add_lightning_args(parser)
+
+    args = parser.parse_args()
+    args.from_ts = parse_time_arg(args.from_ts)
+    args.to_ts = parse_time_arg(args.to_ts)
+
+    if not args.png and not args.show and not args.csv:
+        raise SystemExit("use --png to save, --show to display, or --csv to export")
+
+    view_map = {
+        "theory": plot_price_level,
+        "baseline-base": plot_baseline_base,
+        "baseline-ppm": plot_baseline_ppm,
+        "size": plot_size_mult,
+        "balance": plot_balance_mult,
+        "advertised-base": plot_set_base,
+        "advertised-ppm": plot_set_ppm,
+        "earnings": plot_earnings,
+        "combo": plot_combo,
+    }
+    view_map[args.view](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -1,0 +1,1064 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import json
+import math
+import os
+import re
+import sqlite3
+import subprocess
+import shutil
+import sys
+from datetime import datetime, timedelta, timezone
+
+from clboss.alias_cache import is_nodeid, load_cache, lookup_alias, lookup_nodeid_by_alias
+
+PLOT_LINEWIDTH = 1.5
+SCID_RE = re.compile(r"^\d+x\d+x\d+$")
+FEE_SYMLOG_LINTHRESH = 1.0
+FEE_SYMLOG_LINSCALE = 0.3
+
+
+def local_tz():
+    return datetime.now().astimezone().tzinfo
+
+
+def normalize_dt(dt):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=local_tz())
+    return dt.astimezone(timezone.utc)
+
+
+def parse_ts_iso(ts):
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return normalize_dt(datetime.fromisoformat(ts))
+
+
+def parse_ts_epoch(ts):
+    if isinstance(ts, (int, float)):
+        return datetime.fromtimestamp(ts, timezone.utc)
+    try:
+        return datetime.fromtimestamp(float(ts), timezone.utc)
+    except (TypeError, ValueError):
+        return parse_ts_iso(ts)
+
+
+def parse_ts(ts):
+    return parse_ts_epoch(ts)
+
+
+def make_engineering_formatter():
+    try:
+        from matplotlib.ticker import ScalarFormatter
+    except Exception:
+        return None
+
+    class EngineeringScalarFormatter(ScalarFormatter):
+        def _set_order_of_magnitude(self, *args, **kwargs):
+            super()._set_order_of_magnitude(*args, **kwargs)
+            order = self.orderOfMagnitude
+            if order != 0:
+                self.orderOfMagnitude = int(math.floor(order / 3.0) * 3)
+
+    formatter = EngineeringScalarFormatter(useMathText=True)
+    formatter.set_scientific(True)
+    formatter.set_powerlimits((0, 0))
+    return formatter
+
+
+def safe_prefix(value):
+    sanitized = []
+    for ch in value:
+        if ch.isalnum() or ch in "._-":
+            sanitized.append(ch)
+        else:
+            sanitized.append("_")
+    return "".join(sanitized).strip("_") or "peer"
+
+
+def is_scid(value):
+    return bool(SCID_RE.match(value))
+
+
+def parse_time_arg(value):
+    if value is None:
+        return None
+    # Ideally, we'd accept the same time arguments as journalctl.
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    if re.match(r"^[0-9]{4}-[0-9]{2}$", value):
+        return normalize_dt(datetime.fromisoformat(f"{value}-01T00:00:00"))
+    if re.match(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$", value):
+        return normalize_dt(datetime.fromisoformat(f"{value}T00:00:00"))
+    rel = re.match(r"^([+-]?)(\d+)([smhdw])$", value)
+    if rel:
+        sign, num_s, unit = rel.groups()
+        num = int(num_s)
+        delta = {
+            "s": timedelta(seconds=num),
+            "m": timedelta(minutes=num),
+            "h": timedelta(hours=num),
+            "d": timedelta(days=num),
+            "w": timedelta(weeks=num),
+        }[unit]
+        if sign == "-":
+            delta = -delta
+        return normalize_dt(datetime.now() + delta)
+    if value.count(":") in (1, 2) and "T" not in value and "-" not in value:
+        today = datetime.now().date().isoformat()
+        return normalize_dt(datetime.fromisoformat(f"{today}T{value}"))
+    return normalize_dt(datetime.fromisoformat(value))
+
+
+def price_level_to_mult(level):
+    import numpy as np
+
+    arr = np.asarray(level, dtype=float)
+    mult = np.where(
+        arr < 0,
+        np.power(0.8, -arr),
+        np.where(arr > 0, np.power(1.2, arr), 1.0),
+    )
+    if np.isscalar(level):
+        return float(mult)
+    return mult
+
+
+def price_mult_to_level(mult):
+    import numpy as np
+
+    arr = np.asarray(mult, dtype=float)
+    level = np.zeros_like(arr, dtype=float)
+    lt_one = (arr > 0) & (arr < 1)
+    gt_one = arr > 1
+    if np.any(lt_one):
+        level[lt_one] = -np.log(arr[lt_one]) / np.log(0.8)
+    if np.any(gt_one):
+        level[gt_one] = np.log(arr[gt_one]) / np.log(1.2)
+    if np.isscalar(mult):
+        return float(level)
+    return level
+
+
+def format_mult_tick(value):
+    if value == 0:
+        return "0"
+    if value < 1:
+        nice_values = [
+            (0.5, "0.5"),
+            (0.2, "0.2"),
+            (0.1, "0.10"),
+            (0.05, "0.05"),
+            (0.02, "0.02"),
+            (0.01, "0.01"),
+        ]
+        for target, label in nice_values:
+            if abs(value - target) / target <= 0.08:
+                return label
+    abs_val = abs(value)
+    for decimals in (0, 1, 2):
+        rounded = round(value, decimals)
+        if rounded != 0 and abs(value - rounded) / abs_val < 0.01:
+            if decimals == 0:
+                return str(int(round(rounded)))
+            text = f"{rounded:.{decimals}f}"
+            return text.rstrip("0").rstrip(".")
+    return f"{value:.3g}"
+
+
+def nice_mult_ticks(vmin, vmax):
+    if vmin <= 0 or vmax <= 0:
+        return []
+    if vmin > vmax:
+        vmin, vmax = vmax, vmin
+    exp_min = int(math.floor(math.log10(vmin)))
+    exp_max = int(math.ceil(math.log10(vmax)))
+    mantissas = [1, 2, 5]
+    ticks = []
+    for exp in range(exp_min, exp_max + 1):
+        base = 10 ** exp
+        for m in mantissas:
+            value = m * base
+            if vmin <= value <= vmax:
+                ticks.append(value)
+    if not ticks:
+        if vmin == vmax:
+            return [vmin]
+        return [vmin, vmax]
+    return ticks
+
+
+def pad_top(ax, frac=0.2):
+    ymin, ymax = ax.get_ylim()
+    data_max = ax.dataLim.ymax
+    if data_max <= 0:
+        return
+    target_top = data_max * (1.0 + frac)
+    ax.set_ylim(bottom=ymin, top=target_top)
+
+
+def set_log_ylim(ax, values, pad_frac=0.2, min_floor=0.9, min_top=10):
+    if not values:
+        return
+    max_val = max(values)
+    if max_val < min_floor:
+        max_val = min_floor
+    top = max(max_val * (1.0 + pad_frac), min_top)
+    bottom = min_floor
+    ax.set_ylim(bottom=bottom, top=top)
+
+
+def set_log_ylim_from_ax(ax, pad_frac=0.2, min_floor=0.9, min_top=10):
+    max_val = ax.dataLim.ymax
+    if max_val <= 0:
+        return
+    top = max(max_val * (1.0 + pad_frac), min_top)
+    bottom = min_floor
+    ax.set_ylim(bottom=bottom, top=top)
+
+
+def set_log_decade_ticks(ax):
+    ymin, ymax = ax.get_ylim()
+    if ymin <= 0 or ymax <= 0:
+        return
+    exp_min = int(math.floor(math.log10(ymin)))
+    exp_max = int(math.ceil(math.log10(ymax)))
+    ticks = [10 ** e for e in range(exp_min, exp_max + 1) if 10 ** e >= 1]
+    labels = [str(int(t)) for t in ticks]
+    ax.set_yticks(ticks)
+    ax.set_yticklabels(labels)
+
+
+def set_symlog_ylim(
+    ax,
+    values,
+    clamp_zero=False,
+    pad_frac=0.1,
+    min_pad=1.0,
+    min_bottom=None,
+    max_bottom=None,
+    min_top=None,
+):
+    if not values:
+        return
+    vmin = min(values)
+    vmax = max(values)
+    if vmin == vmax:
+        pad = max(abs(vmin) * pad_frac, min_pad)
+    else:
+        pad = (vmax - vmin) * pad_frac
+    bottom = vmin - pad
+    top = vmax + pad
+    if clamp_zero and bottom < 0:
+        bottom = 0
+    if min_bottom is not None and bottom > min_bottom:
+        bottom = min_bottom
+    if max_bottom is not None and bottom < max_bottom:
+        bottom = max_bottom
+    if min_top is not None and top < min_top:
+        top = min_top
+    ax.set_ylim(bottom=bottom, top=top)
+
+
+def set_symlog_ticks(ax, linthresh, symmetric=True):
+    ymin, ymax = ax.get_ylim()
+    max_abs = max(abs(ymin), abs(ymax))
+    if max_abs <= 0:
+        ax.set_yticks([0])
+        ax.set_yticklabels(["0"])
+        return
+    max_exp = int(math.floor(math.log10(max_abs)))
+    ticks = [0.0]
+    for exp in range(0, max_exp + 1):
+        tick = 10 ** exp
+        if tick < linthresh or tick > max_abs:
+            continue
+        if symmetric:
+            ticks.extend([-tick, tick])
+        else:
+            ticks.append(tick)
+    ticks = sorted(set(ticks))
+    labels = []
+    for tick in ticks:
+        if tick == 0:
+            labels.append("0")
+        else:
+            labels.append(str(int(tick)))
+    ax.set_yticks(ticks)
+    ax.set_yticklabels(labels)
+
+
+def add_common_args(parser):
+    parser.add_argument(
+        "--db",
+        default=os.path.expanduser("./clboss-fee-info.sqlite3"),
+        help="Path to sqlite database.",
+    )
+    parser.add_argument(
+        "--png",
+        nargs="?",
+        const="__DEFAULT__",
+        default=None,
+        help="Output image path.",
+    )
+    parser.add_argument(
+        "--csv",
+        nargs="?",
+        const="__DEFAULT__",
+        default=None,
+        help="Output CSV path.",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Show the plot interactively.",
+    )
+    parser.add_argument(
+        "--since",
+        dest="from_ts",
+        default=None,
+        help="Start time (ISO-8601 or HH:MM[:SS]).",
+    )
+    parser.add_argument(
+        "--before",
+        dest="to_ts",
+        default=None,
+        help="End time (ISO-8601 or HH:MM[:SS]).",
+    )
+
+
+def add_lightning_args(parser):
+    parser.add_argument("--mainnet", action="store_true", help="Run on mainnet")
+    parser.add_argument("--testnet", action="store_true", help="Run on testnet")
+    parser.add_argument("--signet", action="store_true", help="Run on signet")
+    parser.add_argument("--regtest", action="store_true", help="Run on regtest")
+    parser.add_argument("--network", help="Set the network explicitly")
+    parser.add_argument("--lightning-dir", help="lightning data location")
+
+
+def resolve_network_option(args):
+    if args.network:
+        return f"--network={args.network}"
+    if args.testnet:
+        return "--network=testnet"
+    if args.signet:
+        return "--network=signet"
+    if args.regtest:
+        return "--network=regtest"
+    return "--network=bitcoin"
+
+
+def resolve_lightning_dir(args):
+    if args.lightning_dir:
+        if not os.path.isdir(args.lightning_dir):
+            raise ValueError(f'"{args.lightning_dir}" is not a valid directory')
+        return args.lightning_dir
+    return None
+
+
+def run_lightning_cli_command(lightning_dir, network_option, subcommand, *args):
+    try:
+        command = ["lightning-cli", network_option, subcommand, *args]
+        if lightning_dir:
+            command = command[:2] \
+                + [f"--lightning-dir={lightning_dir}"] \
+                + command[2:]
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Command '{command}' failed with error: {e}")
+    except FileNotFoundError:
+        print("lightning-cli not found in PATH.")
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse JSON from command '{command}': {e}")
+    return None
+
+
+def lookup_nodeid_by_scid(run_lightning_cli_command, lightning_dir, network_option, scid):
+    listpeerchannels_data = run_lightning_cli_command(
+        lightning_dir, network_option, "listpeerchannels"
+    )
+    if not listpeerchannels_data:
+        return None
+    channels = listpeerchannels_data.get("channels", [])
+    for channel in channels:
+        if channel.get("short_channel_id") == scid:
+            return channel.get("peer_id")
+    return None
+
+
+def resolve_peer(args):
+    peer_input = args.peer
+    if is_nodeid(peer_input):
+        return peer_input, peer_input
+
+    cli_available = shutil.which("lightning-cli") is not None
+    network_option = resolve_network_option(args)
+    lightning_dir = resolve_lightning_dir(args)
+
+    if is_scid(peer_input):
+        if not cli_available:
+            raise SystemExit(
+                "Error: lightning-cli not found. Provide a nodeid for SCID inputs."
+            )
+        peer_id = lookup_nodeid_by_scid(
+            run_lightning_cli_command, lightning_dir, network_option, peer_input
+        )
+        if not peer_id:
+            raise SystemExit(f"Error: SCID '{peer_input}' not found.")
+        alias = lookup_alias(
+            run_lightning_cli_command, lightning_dir, network_option, peer_id
+        )
+        if alias and alias != peer_id:
+            return peer_id, f"{alias} ({peer_input})"
+        return peer_id, peer_input
+
+    alias = peer_input
+    if cli_available:
+        peer_id = lookup_nodeid_by_alias(
+            run_lightning_cli_command, lightning_dir, network_option, alias
+        )
+    else:
+        cache = load_cache()
+        peer_id = None
+        for node_id, cached_alias in cache.items():
+            if cached_alias == alias:
+                peer_id = node_id
+                break
+    if not peer_id:
+        if not cli_available:
+            raise SystemExit(
+                "Error: lightning-cli not found and alias not in cache. "
+                "Provide a nodeid or ensure lightning-cli is in PATH."
+            )
+        raise SystemExit(f"Error: Alias '{alias}' not found.")
+    return peer_id, alias
+
+
+def filter_by_time(rows, from_ts, to_ts):
+    if from_ts is None and to_ts is None:
+        return rows
+    filtered = []
+    for row in rows:
+        ts = parse_ts(row[0])
+        if from_ts and ts < from_ts:
+            continue
+        if to_ts and ts > to_ts:
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def fetch_earnings_rows(args):
+    if shutil.which("lightning-cli") is None:
+        print("warning: lightning-cli not found; skipping earnings plot", file=sys.stderr)
+        return []
+
+    network_option = resolve_network_option(args)
+    lightning_dir = resolve_lightning_dir(args)
+    data = run_lightning_cli_command(
+        lightning_dir, network_option, "clboss-earnings-history", args.peer
+    )
+    if not data or "history" not in data:
+        print("warning: earnings data unavailable; skipping earnings plot", file=sys.stderr)
+        return []
+
+    rows = []
+    for entry in data["history"]:
+        bucket_time = entry.get("bucket_time")
+        if not bucket_time:
+            continue
+        in_earnings = entry.get("in_earnings", 0)
+        out_earnings = entry.get("out_earnings", 0)
+        rows.append((bucket_time, in_earnings, out_earnings))
+
+    return filter_by_time(rows, args.from_ts, args.to_ts)
+
+
+def get_out_path(args, suffix):
+    if args.png is None:
+        return None
+    if args.png == "__DEFAULT__":
+        prefix = safe_prefix(args.peer_input)[:32]
+        return f"{prefix}-{suffix}.png"
+    return args.png
+
+
+def get_csv_path(args, suffix):
+    if args.csv is None:
+        return None
+    if args.csv == "__DEFAULT__":
+        prefix = safe_prefix(args.peer_input)[:32]
+        return f"{prefix}-{suffix}.csv"
+    return args.csv
+
+
+def write_csv(args, rows, suffix):
+    path = get_csv_path(args, suffix)
+    if not path:
+        return
+    headers = [
+        "ts",
+        "peer",
+        "set_base",
+        "set_ppm",
+        "baseline_base",
+        "baseline_ppm",
+        "size_mult",
+        "size_total_peers",
+        "size_less_peers",
+        "balance_mult",
+        "balance_our_msat",
+        "balance_total_msat",
+        "price_level",
+        "price_mult",
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+        writer.writerows(rows)
+
+
+CSV_QUERY = (
+    "SELECT f.ts, p.node_id, f.set_base, f.set_ppm, "
+    "f.baseline_base, f.baseline_ppm, f.size_mult, "
+    "f.size_total_peers, f.size_less_peers, f.balance_mult, "
+    "f.balance_our_msat, f.balance_total_msat, "
+    "f.price_level, f.price_mult "
+    "FROM fee_change_events f "
+    "JOIN peers p ON p.id = f.peer_id "
+    "WHERE p.node_id = ? ORDER BY f.ts"
+)
+
+
+def fetch_rows(db, query, peer):
+    with sqlite3.connect(db) as conn:
+        return conn.execute(query, (peer,)).fetchall()
+
+
+def fetch_csv_rows(args):
+    rows = fetch_rows(args.db, CSV_QUERY, args.peer)
+    return filter_by_time(rows, args.from_ts, args.to_ts)
+
+
+def make_single_axes(plt):
+    fig, ax = plt.subplots(figsize=(12, 4))
+    return fig, ax, (ax,)
+
+
+def make_twin_axes(plt):
+    fig, ax_left = plt.subplots(figsize=(12, 4))
+    ax_right = ax_left.twinx()
+    return fig, ax_left, (ax_left, ax_right)
+
+
+def plot_single_view(
+    args, suffix, rows_query, axes_factory, plotter, use_plt_tight_layout=False
+):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    rows = fetch_rows(args.db, rows_query, args.peer)
+    rows = filter_by_time(rows, args.from_ts, args.to_ts)
+    csv_rows = fetch_csv_rows(args)
+
+    fig, primary_ax, plot_axes = axes_factory(plt)
+    plotter(*plot_axes, rows, args.peer_label)
+    primary_ax.set_xlabel("time")
+    primary_ax.set_title(args.peer_label)
+
+    if use_plt_tight_layout:
+        plt.tight_layout()
+    else:
+        fig.tight_layout()
+    out_path = get_out_path(args, suffix)
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, csv_rows, suffix)
+
+
+def plot_price_level_on(ax_level, rows, peer):
+    rows = [r for r in rows if r[1] is not None]
+    ts_levels = []
+    levels = []
+    for t, level, _ in rows:
+        ts = parse_ts(t)
+        ts_levels.append(ts)
+        levels.append(level)
+
+    if not ts_levels:
+        raise SystemExit("no theory_level data for peer in time range")
+
+    level_line, = ax_level.plot(
+        ts_levels,
+        levels,
+        linewidth=PLOT_LINEWIDTH,
+        label="theory_level",
+        color="orange",
+    )
+
+    ax_level.set_ylabel("theory_level")
+    ax_mult = ax_level.secondary_yaxis(
+        "right",
+        functions=(price_level_to_mult, price_mult_to_level),
+    )
+    ax_mult.set_ylabel("theory_mult")
+    ax_level.legend([level_line], ["theory_level"])
+    pad_top(ax_level)
+    mult_min = price_level_to_mult(min(levels))
+    mult_max = price_level_to_mult(max(levels))
+    mult_ticks = nice_mult_ticks(mult_min, mult_max)
+    if mult_ticks:
+        ax_mult.set_yticks(mult_ticks)
+        ax_mult.set_yticklabels([format_mult_tick(v) for v in mult_ticks])
+    return ax_mult
+
+
+def plot_base_ppm_on(ax_base, ax_ppm, rows, peer):
+
+    rows = [r for r in rows if r[1] is not None and r[2] is not None]
+    ts = []
+    bases = []
+    ppms = []
+    for t, base, ppm in rows:
+        ts.append(parse_ts(t))
+        bases.append(base)
+        ppms.append(ppm)
+
+    if not ts:
+        raise SystemExit("no est_base/est_ppm data for peer in time range")
+
+    base_line, = ax_base.plot(ts, bases, linewidth=PLOT_LINEWIDTH, label="base")
+    ppm_line, = ax_ppm.plot(ts, ppms, linewidth=PLOT_LINEWIDTH, label="ppm", color="orange")
+
+    ax_base.set_ylabel("advertised_base")
+    ax_ppm.set_ylabel("advertised_ppm")
+    ax_base.set_yscale(
+        "symlog",
+        linthresh=FEE_SYMLOG_LINTHRESH,
+        linscale=FEE_SYMLOG_LINSCALE,
+    )
+    ax_ppm.set_yscale(
+        "symlog",
+        linthresh=FEE_SYMLOG_LINTHRESH,
+        linscale=FEE_SYMLOG_LINSCALE,
+    )
+
+    base_values = [0.0] + bases
+    ppm_values = [0.0] + ppms
+    ppm_scale_values = [max(0.0, v) for v in ppm_values]
+    base_min = min(base_values)
+    ppm_min = min(ppm_scale_values)
+    base_max_bottom = None if base_min < 0 else -0.1
+    set_symlog_ylim(
+        ax_base,
+        base_values,
+        min_pad=0.1,
+        min_bottom=-0.1,
+        max_bottom=base_max_bottom,
+        min_top=10,
+    )
+    set_symlog_ylim(
+        ax_ppm,
+        ppm_scale_values,
+        min_pad=0.1,
+        min_bottom=-0.1,
+        max_bottom=-0.1,
+        min_top=10,
+    )
+    set_symlog_ticks(ax_base, FEE_SYMLOG_LINTHRESH, symmetric=base_min < 0)
+    set_symlog_ticks(ax_ppm, FEE_SYMLOG_LINTHRESH, symmetric=ppm_min < 0)
+
+    ax_base.legend([base_line, ppm_line], ["advertised_base", "advertised_ppm"])
+
+
+def plot_baseline_on(ax_base, ax_ppm, rows, peer):
+
+    rows = [r for r in rows if r[1] is not None and r[2] is not None]
+    ts = []
+    bases = []
+    ppms = []
+    for t, base, ppm in rows:
+        ts.append(parse_ts(t))
+        bases.append(base)
+        ppms.append(ppm)
+
+    if not ts:
+        raise SystemExit("no baseline data for peer in time range")
+
+    base_line, = ax_base.plot(ts, bases, linewidth=PLOT_LINEWIDTH, label="base")
+    ppm_line, = ax_ppm.plot(ts, ppms, linewidth=PLOT_LINEWIDTH, label="ppm", color="orange")
+
+    ax_base.set_ylabel("baseline_base")
+    ax_ppm.set_ylabel("baseline_ppm")
+
+    ax_base.set_yscale(
+        "symlog",
+        linthresh=FEE_SYMLOG_LINTHRESH,
+        linscale=FEE_SYMLOG_LINSCALE,
+    )
+    ax_ppm.set_yscale(
+        "symlog",
+        linthresh=FEE_SYMLOG_LINTHRESH,
+        linscale=FEE_SYMLOG_LINSCALE,
+    )
+
+    base_values = [0.0] + bases
+    ppm_values = [0.0] + ppms
+    ppm_scale_values = [max(0.0, v) for v in ppm_values]
+    base_min = min(base_values)
+    ppm_min = min(ppm_scale_values)
+    base_max_bottom = None if base_min < 0 else -0.1
+    set_symlog_ylim(
+        ax_base,
+        base_values,
+        min_pad=0.1,
+        min_bottom=-0.1,
+        max_bottom=base_max_bottom,
+        min_top=10,
+    )
+    set_symlog_ylim(
+        ax_ppm,
+        ppm_scale_values,
+        min_pad=0.1,
+        min_bottom=-0.1,
+        max_bottom=-0.1,
+        min_top=10,
+    )
+    set_symlog_ticks(ax_base, FEE_SYMLOG_LINTHRESH, symmetric=base_min < 0)
+    set_symlog_ticks(ax_ppm, FEE_SYMLOG_LINTHRESH, symmetric=ppm_min < 0)
+
+    ax_base.legend([base_line, ppm_line], ["baseline_base", "baseline_ppm"])
+
+
+def plot_size_mult_on(ax_left, ax_right, rows, peer):
+    rows = [
+        r for r in rows
+        if r[1] is not None and r[2] is not None and r[3] is not None
+    ]
+    ts = []
+    totals = []
+    lesses = []
+    mults = []
+    for t, total, less, mult in rows:
+        ts.append(parse_ts(t))
+        totals.append(total)
+        lesses.append(less)
+        mults.append(mult)
+
+    if not ts:
+        raise SystemExit("no size_total_peers data for peer in time range")
+
+    total_line, = ax_left.plot(
+        ts, totals, linewidth=PLOT_LINEWIDTH, label="total_peers", color="green"
+    )
+    less_line, = ax_left.plot(
+        ts, lesses, linewidth=PLOT_LINEWIDTH, label="less_peers"
+    )
+    mult_line, = ax_right.plot(
+        ts, mults, linewidth=PLOT_LINEWIDTH, label="size_mult", color="orange"
+    )
+    ax_left.set_ylabel("peer_count")
+    ax_left.set_ylim(bottom=0)
+    pad_top(ax_left)
+    ax_left.legend(
+        [total_line, less_line, mult_line],
+        ["total_peers", "less_peers", "size_mult"],
+    )
+    ax_right.set_ylabel("size_mult")
+    ax_right.set_yscale("log")
+    ax_right.set_ylim(0.5, 16)
+    ax_right.set_yticks(
+        [0.5, 1, 2, 4, 8, 16],
+        ["1/2", "1", "2", "4", "8", "16"],
+    )
+
+
+def plot_balance_mult_on(ax_left, ax_right, rows, peer):
+    rows = [
+        r for r in rows
+        if r[1] is not None and r[2] is not None and r[3] is not None
+    ]
+    ts = []
+    our_sats = []
+    total_sats = []
+    mults = []
+    for t, our_val, total_val, mult in rows:
+        ts.append(parse_ts(t))
+        our_sats.append(our_val / 1000.0)
+        total_sats.append(total_val / 1000.0)
+        mults.append(mult)
+
+    if not ts:
+        raise SystemExit("no balance data for peer in time range")
+
+    total_line, = ax_left.plot(
+        ts, total_sats, linewidth=PLOT_LINEWIDTH, label="total_balance", color="green"
+    )
+    peer_line, = ax_left.plot(
+        ts, our_sats, linewidth=PLOT_LINEWIDTH, label="our_balance"
+    )
+    mult_line, = ax_right.plot(
+        ts, mults, linewidth=PLOT_LINEWIDTH, color="orange", label="balance_mult"
+    )
+    ax_left.set_ylabel("balance")
+    max_total = max(total_sats) if total_sats else 0
+    if max_total > 0:
+        ax_left.set_ylim(bottom=0 - 0.05, top=max_total * 1.05)
+    else:
+        ax_left.set_ylim(bottom=0 - 0.05)
+    balance_formatter = make_engineering_formatter()
+    if balance_formatter:
+        ax_left.yaxis.set_major_formatter(balance_formatter)
+    ax_left.legend(
+        [total_line, peer_line, mult_line],
+        ["total_balance", "our_balance", "balance_mult"],
+    )
+    ax_right.set_ylabel("balance_mult")
+    ax_right.set_yscale("log")
+    ax_right.set_ylim(1 / 6 * 0.8, 6 * 1.2)
+    ax_right.set_yticks(
+        [1 / 6, 1 / 3, 1, 3, 6],
+        ["1/6", "1/3", "1", "3", "6"],
+    )
+
+
+def plot_earnings_on(ax, rows, peer):
+    ts = []
+    incoming = []
+    outgoing = []
+    sci_formatter = make_engineering_formatter()
+    for t, in_earnings, out_earnings in rows:
+        ts.append(parse_ts(t))
+        incoming.append(in_earnings / 1000.0)
+        outgoing.append(out_earnings / 1000.0)
+
+    if not ts:
+        ax.set_ylabel("earnings (sat/day)")
+        ax.set_ylim(bottom=0)
+        ax.set_title("earnings (no data)")
+        if sci_formatter:
+            ax.yaxis.set_major_formatter(sci_formatter)
+        return
+
+    bar_width = 0.8
+    out_bars = ax.bar(
+        ts,
+        outgoing,
+        width=bar_width,
+        color="green",
+        label="earnings (sat/day) from outgoing",
+    )
+    in_bars = ax.bar(
+        ts,
+        incoming,
+        width=bar_width,
+        bottom=outgoing,
+        color="blue",
+        label="earnings (sat/day) from incoming",
+    )
+
+    ax.set_ylabel("earnings (sat/day)")
+    totals = [in_val + out_val for in_val, out_val in zip(incoming, outgoing)]
+    ax.set_ylim(bottom=0, top=max(1, max(totals) * 1.05))
+    ax.legend([in_bars, out_bars], [
+        "earnings (sat/day) from incoming",
+        "earnings (sat/day) from outgoing",
+    ])
+    if sci_formatter:
+        ax.yaxis.set_major_formatter(sci_formatter)
+
+
+PRICE_LEVEL_QUERY = (
+    "SELECT f.ts, f.price_level, f.price_mult "
+    "FROM fee_change_events f "
+    "JOIN peers p ON p.id = f.peer_id "
+    "WHERE p.node_id = ? ORDER BY f.ts"
+)
+BASE_PPM_QUERY = (
+    "SELECT f.ts, f.set_base, f.set_ppm FROM fee_change_events f "
+    "JOIN peers p ON p.id = f.peer_id "
+    "WHERE p.node_id = ? ORDER BY f.ts"
+)
+BASELINE_QUERY = (
+    "SELECT f.ts, f.baseline_base, f.baseline_ppm FROM fee_change_events f "
+    "JOIN peers p ON p.id = f.peer_id "
+    "WHERE p.node_id = ? ORDER BY f.ts"
+)
+SIZE_MULT_QUERY = (
+    "SELECT f.ts, f.size_total_peers, f.size_less_peers, f.size_mult "
+    "FROM fee_change_events f "
+    "JOIN peers p ON p.id = f.peer_id "
+    "WHERE p.node_id = ? ORDER BY f.ts"
+)
+BALANCE_MULT_QUERY = (
+    "SELECT f.ts, f.balance_our_msat, f.balance_total_msat, f.balance_mult "
+    "FROM fee_change_events f "
+    "JOIN peers p ON p.id = f.peer_id "
+    "WHERE p.node_id = ? ORDER BY f.ts"
+)
+
+
+def plot_price_level(args):
+    plot_single_view(
+        args,
+        "theory",
+        PRICE_LEVEL_QUERY,
+        make_single_axes,
+        plot_price_level_on,
+    )
+
+
+def plot_base_ppm(args):
+    plot_single_view(
+        args,
+        "baseppm",
+        BASE_PPM_QUERY,
+        make_twin_axes,
+    plot_base_ppm_on,
+    )
+    # Keep symlog tick formatting from plot_base_ppm_on.
+
+
+def plot_baseline(args):
+    plot_single_view(
+        args,
+        "baseline",
+        BASELINE_QUERY,
+        make_twin_axes,
+    plot_baseline_on,
+    )
+    # Keep symlog tick formatting from plot_baseline_on.
+
+
+def plot_size_mult(args):
+    plot_single_view(
+        args,
+        "size",
+        SIZE_MULT_QUERY,
+        make_twin_axes,
+        plot_size_mult_on,
+        use_plt_tight_layout=True,
+    )
+
+
+def plot_balance_mult(args):
+    plot_single_view(
+        args,
+        "balance",
+        BALANCE_MULT_QUERY,
+        make_twin_axes,
+        plot_balance_mult_on,
+        use_plt_tight_layout=True,
+    )
+
+
+def plot_combo(args):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+
+    size_rows = fetch_rows(args.db, SIZE_MULT_QUERY, args.peer)
+    baseline_rows = fetch_rows(args.db, BASELINE_QUERY, args.peer)
+    balance_rows = fetch_rows(args.db, BALANCE_MULT_QUERY, args.peer)
+    price_rows = fetch_rows(args.db, PRICE_LEVEL_QUERY, args.peer)
+    base_rows = fetch_rows(args.db, BASE_PPM_QUERY, args.peer)
+    csv_rows = fetch_rows(args.db, CSV_QUERY, args.peer)
+    earnings_rows = fetch_earnings_rows(args)
+
+    size_rows = filter_by_time(size_rows, args.from_ts, args.to_ts)
+    baseline_rows = filter_by_time(baseline_rows, args.from_ts, args.to_ts)
+    balance_rows = filter_by_time(balance_rows, args.from_ts, args.to_ts)
+    price_rows = filter_by_time(price_rows, args.from_ts, args.to_ts)
+    base_rows = filter_by_time(base_rows, args.from_ts, args.to_ts)
+    csv_rows = filter_by_time(csv_rows, args.from_ts, args.to_ts)
+    fig, axes = plt.subplots(6, 1, figsize=(12, 18), sharex=True)
+    ax_baseline, ax_size, ax_balance, ax_price, ax_base, ax_earnings = axes
+
+    ax_baseline_base = ax_baseline
+    ax_baseline_ppm = ax_baseline_base.twinx()
+    plot_baseline_on(
+        ax_baseline_base, ax_baseline_ppm, baseline_rows, args.peer_label
+    )
+
+    ax_size_right = ax_size.twinx()
+    plot_size_mult_on(ax_size, ax_size_right, size_rows, args.peer_label)
+    ax_balance_right = ax_balance.twinx()
+    plot_balance_mult_on(ax_balance, ax_balance_right, balance_rows, args.peer_label)
+
+    ax_price_level = ax_price
+    ax_price_mult = plot_price_level_on(ax_price_level, price_rows, args.peer_label)
+
+    ax_base_fee = ax_base
+    ax_base_ppm = ax_base_fee.twinx()
+    plot_base_ppm_on(ax_base_fee, ax_base_ppm, base_rows, args.peer_label)
+
+    plot_earnings_on(ax_earnings, earnings_rows, args.peer_label)
+
+    fig.suptitle(args.peer_label)
+    fig.tight_layout(rect=[0, 0, 1, 0.96])
+    fig.subplots_adjust(hspace=0.15)
+
+    out_path = get_out_path(args, "combo")
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, csv_rows, "combo")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Plot fee-related time series from clboss fee logs."
+    )
+    parser.add_argument(
+        "--view",
+        required=True,
+        choices=[
+            "theory",
+            "base-ppm",
+            "baseline",
+            "size",
+            "balance",
+            "combo",
+        ],
+        help="Plot view to render.",
+    )
+    parser.add_argument(
+        "--peer",
+        required=True,
+        help="Peer nodeid (hex), alias, or SCID.",
+    )
+    add_lightning_args(parser)
+    add_common_args(parser)
+
+    args = parser.parse_args()
+    args.peer_input = args.peer
+    args.from_ts = parse_time_arg(args.from_ts)
+    args.to_ts = parse_time_arg(args.to_ts)
+    args.peer, args.peer_label = resolve_peer(args)
+
+    if not args.png and not args.show and not args.csv:
+        raise SystemExit("use --png to save, --show to display, or --csv to export")
+
+    view_map = {
+        "theory": plot_price_level,
+        "base-ppm": plot_base_ppm,
+        "baseline": plot_baseline,
+        "size": plot_size_mult,
+        "balance": plot_balance_mult,
+        "combo": plot_combo,
+    }
+    view_map[args.view](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -932,6 +932,55 @@ def plot_earnings_split(ax_out, ax_in, rows, peer):
     ax_in.legend(handles=[in_bars], labels=["earnings (sat/day) incoming"])
 
 
+def plot_earnings_single_on(ax, rows, direction):
+    incoming = direction == "incoming"
+    label = "incoming" if incoming else "outgoing"
+    color = "blue" if incoming else "green"
+    ts = []
+    values = []
+    for t, in_earnings, out_earnings in rows:
+        ts.append(parse_ts(t))
+        value = in_earnings if incoming else out_earnings
+        values.append(value / 1000.0)
+
+    ax.set_ylabel(f"earnings (sat/day) {label}")
+    ax.set_yscale(
+        "symlog",
+        linthresh=EARNINGS_SYMLOG_LINTHRESH,
+        linscale=EARNINGS_SYMLOG_LINSCALE,
+    )
+    if not ts:
+        set_symlog_ylim(
+            ax,
+            [0.0],
+            clamp_zero=True,
+            min_bottom=0,
+            min_top=EARNINGS_SYMLOG_LINTHRESH,
+        )
+        set_symlog_ticks(ax, EARNINGS_SYMLOG_LINTHRESH, symmetric=False)
+        ax.set_title(f"earnings (no data) {label}")
+        return
+
+    bar_width = timedelta(days=0.8)
+    bars = ax.bar(
+        ts,
+        values,
+        width=bar_width,
+        align="edge",
+        color=color,
+        label=f"earnings (sat/day) {label}",
+    )
+    set_symlog_ylim(
+        ax,
+        [0.0] + values,
+        clamp_zero=True,
+        min_bottom=0,
+        min_top=EARNINGS_SYMLOG_LINTHRESH,
+    )
+    set_symlog_ticks(ax, EARNINGS_SYMLOG_LINTHRESH, symmetric=False)
+    ax.legend(handles=[bars], labels=[f"earnings (sat/day) {label}"])
+
+
 PRICE_LEVEL_QUERY = (
     "SELECT f.ts, f.price_level, f.price_mult "
     "FROM fee_change_events f "
@@ -1104,6 +1153,42 @@ def plot_combo(args):
     write_csv(args, csv_rows, "combo")
 
 
+def plot_earnings_single(args, direction, suffix):
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        raise SystemExit("matplotlib is required to output graphs.")
+    else:
+        import matplotlib as mpl
+
+        mpl.rcParams["timezone"] = "UTC"
+
+    rows = fetch_earnings_rows(args)
+    csv_rows = fetch_csv_rows(args)
+
+    fig, ax = plt.subplots(figsize=(12, 4))
+    ax.set_title(args.title)
+    plot_earnings_single_on(ax, rows, direction)
+    ax.set_xlabel("time")
+    fig.tight_layout()
+
+    out_path = get_out_path(args, suffix)
+    if out_path:
+        plt.savefig(out_path, dpi=150)
+
+    if args.show:
+        plt.show()
+    write_csv(args, csv_rows, suffix)
+
+
+def plot_earnings_incoming(args):
+    plot_earnings_single(args, "incoming", "earnings-incoming")
+
+
+def plot_earnings_outgoing(args):
+    plot_earnings_single(args, "outgoing", "earnings-outgoing")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Plot fee-related time series from clboss fee logs."
@@ -1117,6 +1202,8 @@ def main():
             "baseline",
             "size",
             "balance",
+            "incoming-earnings",
+            "outgoing-earnings",
             "combo",
         ],
         help="Plot view to render.",
@@ -1145,6 +1232,8 @@ def main():
         "baseline": plot_baseline,
         "size": plot_size_mult,
         "balance": plot_balance_mult,
+        "incoming-earnings": plot_earnings_incoming,
+        "outgoing-earnings": plot_earnings_outgoing,
         "combo": plot_combo,
     }
     view_map[args.view](args)

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -18,6 +18,11 @@ SCID_RE = re.compile(r"^\d+x\d+x\d+$")
 FEE_SYMLOG_LINTHRESH = 1.0
 FEE_SYMLOG_LINSCALE = 0.3
 
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
 
 def local_tz():
     return datetime.now().astimezone().tzinfo
@@ -112,7 +117,14 @@ def parse_time_arg(value):
 
 
 def price_level_to_mult(level):
-    import numpy as np
+    if np is None:
+        if isinstance(level, (int, float)):
+            if level < 0:
+                return math.pow(0.8, -level)
+            if level > 0:
+                return math.pow(1.2, level)
+            return 1.0
+        return [price_level_to_mult(v) for v in level]
 
     arr = np.asarray(level, dtype=float)
     mult = np.where(
@@ -126,7 +138,14 @@ def price_level_to_mult(level):
 
 
 def price_mult_to_level(mult):
-    import numpy as np
+    if np is None:
+        if isinstance(mult, (int, float)):
+            if mult < 1:
+                return -math.log(mult) / math.log(0.8)
+            if mult > 1:
+                return math.log(mult) / math.log(1.2)
+            return 0.0
+        return [price_mult_to_level(v) for v in mult]
 
     arr = np.asarray(mult, dtype=float)
     level = np.zeros_like(arr, dtype=float)

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -367,11 +367,11 @@ def run_lightning_cli_command(lightning_dir, network_option, subcommand, *args):
         result = subprocess.run(command, capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
     except subprocess.CalledProcessError as e:
-        print(f"Command '{command}' failed with error: {e}")
+        print(f"Command '{command}' failed with error: {e}", file=sys.stderr)
     except FileNotFoundError:
-        print("lightning-cli not found in PATH.")
+        print("lightning-cli not found in PATH.", file=sys.stderr)
     except json.JSONDecodeError as e:
-        print(f"Failed to parse JSON from command '{command}': {e}")
+        print(f"Failed to parse JSON from command '{command}': {e}", file=sys.stderr)
     return None
 
 

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -336,6 +336,13 @@ def add_common_args(parser):
         help="Show the plot interactively.",
     )
     parser.add_argument(
+        "--title",
+        nargs="?",
+        const="",
+        default=None,
+        help="Plot title (defaults to peer label; pass empty to omit).",
+    )
+    parser.add_argument(
         "--since",
         dest="from_ts",
         default=None,
@@ -593,7 +600,7 @@ def plot_single_view(
     fig, primary_ax, plot_axes = axes_factory(plt)
     plotter(*plot_axes, rows, args.peer_label)
     primary_ax.set_xlabel("time")
-    primary_ax.set_title(args.peer_label)
+    primary_ax.set_title(args.title)
 
     if use_plt_tight_layout:
         plt.tight_layout()
@@ -1084,7 +1091,7 @@ def plot_combo(args):
     if all_times:
         ax_baseline.set_xlim(min(all_times), max(all_times))
 
-    fig.suptitle(args.peer_label)
+    fig.suptitle(args.title)
     fig.tight_layout(rect=[0, 0, 1, 0.96])
     fig.subplots_adjust(hspace=0.15)
 
@@ -1127,6 +1134,7 @@ def main():
     args.from_ts = parse_time_arg(args.from_ts)
     args.to_ts = parse_time_arg(args.to_ts)
     args.peer, args.peer_label = resolve_peer(args)
+    args.title = args.peer_label if args.title is None else args.title
 
     if not args.png and not args.show and not args.csv:
         raise SystemExit("use --png to save, --show to display, or --csv to export")

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -25,12 +25,12 @@ except ImportError:
 
 
 def local_tz():
-    return datetime.now().astimezone().tzinfo
+    return timezone.utc
 
 
 def normalize_dt(dt):
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=local_tz())
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
 
 
@@ -109,9 +109,9 @@ def parse_time_arg(value):
         }[unit]
         if sign == "-":
             delta = -delta
-        return normalize_dt(datetime.now() + delta)
+        return normalize_dt(datetime.now(timezone.utc) + delta)
     if value.count(":") in (1, 2) and "T" not in value and "-" not in value:
-        today = datetime.now().date().isoformat()
+        today = datetime.now(timezone.utc).date().isoformat()
         return normalize_dt(datetime.fromisoformat(f"{today}T{value}"))
     return normalize_dt(datetime.fromisoformat(value))
 
@@ -579,6 +579,10 @@ def plot_single_view(
         import matplotlib.pyplot as plt
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
+    else:
+        import matplotlib as mpl
+
+        mpl.rcParams["timezone"] = "UTC"
 
     rows = fetch_rows(args.db, rows_query, args.peer)
     rows = filter_by_time(rows, args.from_ts, args.to_ts)
@@ -987,6 +991,10 @@ def plot_combo(args):
         import matplotlib.pyplot as plt
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
+    else:
+        import matplotlib as mpl
+
+        mpl.rcParams["timezone"] = "UTC"
 
     def extend_times(acc, rows, end_pad=None):
         for row in rows:

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -17,6 +17,8 @@ PLOT_LINEWIDTH = 1.5
 SCID_RE = re.compile(r"^\d+x\d+x\d+$")
 FEE_SYMLOG_LINTHRESH = 1.0
 FEE_SYMLOG_LINSCALE = 0.3
+EARNINGS_SYMLOG_LINTHRESH = 1.0
+EARNINGS_SYMLOG_LINSCALE = 0.3
 
 try:
     import numpy as np
@@ -852,54 +854,75 @@ def plot_balance_mult_on(ax_left, ax_right, rows, peer):
     )
 
 
-def plot_earnings_on(ax, rows, peer):
+def plot_earnings_split(ax_out, ax_in, rows, peer):
     ts = []
     incoming = []
     outgoing = []
-    sci_formatter = make_engineering_formatter()
     for t, in_earnings, out_earnings in rows:
         ts.append(parse_ts(t))
         incoming.append(in_earnings / 1000.0)
         outgoing.append(out_earnings / 1000.0)
 
     if not ts:
-        ax.set_ylabel("earnings (sat/day)")
-        ax.set_ylim(bottom=0)
-        ax.set_title("earnings (no data)")
-        if sci_formatter:
-            ax.yaxis.set_major_formatter(sci_formatter)
+        for ax, label in ((ax_out, "outgoing"), (ax_in, "incoming")):
+            ax.set_ylabel(f"earnings (sat/day) {label}")
+            ax.set_yscale(
+                "symlog",
+                linthresh=EARNINGS_SYMLOG_LINTHRESH,
+                linscale=EARNINGS_SYMLOG_LINSCALE,
+            )
+            set_symlog_ylim(
+                ax,
+                [0.0],
+                clamp_zero=True,
+                min_bottom=0,
+                min_top=EARNINGS_SYMLOG_LINTHRESH,
+            )
+            set_symlog_ticks(ax, EARNINGS_SYMLOG_LINTHRESH, symmetric=False)
+        ax_out.set_title("earnings (no data)")
         return
 
-    # Earnings buckets are daily; draw bars covering the full day starting
-    # at the bucket boundary to avoid spanning multiple days.
-    bar_width = timedelta(days=1)
-    out_bars = ax.bar(
+    # Earnings buckets are daily; draw near-full-day bars starting at the bucket
+    # boundary to preserve UTC alignment while still visually separating days.
+    bar_width = timedelta(days=0.9)
+    out_bars = ax_out.bar(
         ts,
         outgoing,
         width=bar_width,
         align="edge",
         color="green",
-        label="earnings (sat/day) from outgoing",
+        label="earnings (sat/day) outgoing",
     )
-    in_bars = ax.bar(
+    in_bars = ax_in.bar(
         ts,
         incoming,
         width=bar_width,
-        bottom=outgoing,
         align="edge",
         color="blue",
-        label="earnings (sat/day) from incoming",
+        label="earnings (sat/day) incoming",
     )
 
-    ax.set_ylabel("earnings (sat/day)")
-    totals = [in_val + out_val for in_val, out_val in zip(incoming, outgoing)]
-    ax.set_ylim(bottom=0, top=max(1, max(totals) * 1.05))
-    ax.legend([in_bars, out_bars], [
-        "earnings (sat/day) from incoming",
-        "earnings (sat/day) from outgoing",
-    ])
-    if sci_formatter:
-        ax.yaxis.set_major_formatter(sci_formatter)
+    for ax, values, label in (
+        (ax_out, outgoing, "outgoing"),
+        (ax_in, incoming, "incoming"),
+    ):
+        ax.set_ylabel(f"earnings (sat/day) {label}")
+        ax.set_yscale(
+            "symlog",
+            linthresh=EARNINGS_SYMLOG_LINTHRESH,
+            linscale=EARNINGS_SYMLOG_LINSCALE,
+        )
+        set_symlog_ylim(
+            ax,
+            [0.0] + values,
+            clamp_zero=True,
+            min_bottom=0,
+            min_top=EARNINGS_SYMLOG_LINTHRESH,
+        )
+        set_symlog_ticks(ax, EARNINGS_SYMLOG_LINTHRESH, symmetric=False)
+
+    ax_out.legend(handles=[out_bars], labels=["earnings (sat/day) outgoing"])
+    ax_in.legend(handles=[in_bars], labels=["earnings (sat/day) incoming"])
 
 
 PRICE_LEVEL_QUERY = (
@@ -1020,8 +1043,16 @@ def plot_combo(args):
     price_rows = filter_by_time(price_rows, args.from_ts, args.to_ts)
     base_rows = filter_by_time(base_rows, args.from_ts, args.to_ts)
     csv_rows = filter_by_time(csv_rows, args.from_ts, args.to_ts)
-    fig, axes = plt.subplots(6, 1, figsize=(12, 18), sharex=True)
-    ax_baseline, ax_size, ax_balance, ax_price, ax_base, ax_earnings = axes
+    fig, axes = plt.subplots(7, 1, figsize=(12, 21), sharex=True)
+    (
+        ax_baseline,
+        ax_size,
+        ax_balance,
+        ax_price,
+        ax_base,
+        ax_earnings_out,
+        ax_earnings_in,
+    ) = axes
 
     ax_baseline_base = ax_baseline
     ax_baseline_ppm = ax_baseline_base.twinx()
@@ -1041,7 +1072,7 @@ def plot_combo(args):
     ax_base_ppm = ax_base_fee.twinx()
     plot_base_ppm_on(ax_base_fee, ax_base_ppm, base_rows, args.peer_label)
 
-    plot_earnings_on(ax_earnings, earnings_rows, args.peer_label)
+    plot_earnings_split(ax_earnings_out, ax_earnings_in, earnings_rows, args.peer_label)
 
     all_times = []
     extend_times(all_times, baseline_rows)

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -884,7 +884,7 @@ def plot_earnings_split(ax_out, ax_in, rows, peer):
 
     # Earnings buckets are daily; draw near-full-day bars starting at the bucket
     # boundary to preserve UTC alignment while still visually separating days.
-    bar_width = timedelta(days=0.9)
+    bar_width = timedelta(days=0.8)
     out_bars = ax_out.bar(
         ts,
         outgoing,

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -866,11 +866,14 @@ def plot_earnings_on(ax, rows, peer):
             ax.yaxis.set_major_formatter(sci_formatter)
         return
 
-    bar_width = 0.8
+    # Earnings buckets are daily; draw bars covering the full day starting
+    # at the bucket boundary to avoid spanning multiple days.
+    bar_width = timedelta(days=1)
     out_bars = ax.bar(
         ts,
         outgoing,
         width=bar_width,
+        align="edge",
         color="green",
         label="earnings (sat/day) from outgoing",
     )
@@ -879,6 +882,7 @@ def plot_earnings_on(ax, rows, peer):
         incoming,
         width=bar_width,
         bottom=outgoing,
+        align="edge",
         color="blue",
         label="earnings (sat/day) from incoming",
     )
@@ -984,6 +988,16 @@ def plot_combo(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
+    def extend_times(acc, rows, end_pad=None):
+        for row in rows:
+            ts_val = row[0]
+            if ts_val is None:
+                continue
+            ts = parse_ts(ts_val)
+            acc.append(ts)
+            if end_pad:
+                acc.append(ts + end_pad)
+
     size_rows = fetch_rows(args.db, SIZE_MULT_QUERY, args.peer)
     baseline_rows = fetch_rows(args.db, BASELINE_QUERY, args.peer)
     balance_rows = fetch_rows(args.db, BALANCE_MULT_QUERY, args.peer)
@@ -1020,6 +1034,16 @@ def plot_combo(args):
     plot_base_ppm_on(ax_base_fee, ax_base_ppm, base_rows, args.peer_label)
 
     plot_earnings_on(ax_earnings, earnings_rows, args.peer_label)
+
+    all_times = []
+    extend_times(all_times, baseline_rows)
+    extend_times(all_times, size_rows)
+    extend_times(all_times, balance_rows)
+    extend_times(all_times, price_rows)
+    extend_times(all_times, base_rows)
+    extend_times(all_times, earnings_rows, end_pad=timedelta(days=1))
+    if all_times:
+        ax_baseline.set_xlim(min(all_times), max(all_times))
 
     fig.suptitle(args.peer_label)
     fig.tight_layout(rect=[0, 0, 1, 0.96])


### PR DESCRIPTION
This PR adds two components:
- a debug log postprocessor which extracts fee setting info and saves it in a sqlite db
- a plotting utility which visualizes the data in the db

Sample output:
<img width="1800" height="2700" alt="carefuleagle2-combo" src="https://github.com/user-attachments/assets/d7293566-a80b-459b-9809-67a479006db9" />

Explanation:
- The top graph shows the median fees (the baseline) for all the other channels into the target peer
- The 2nd graph is the "size premium/discount" for our capacity vs the others (if we are bigger we set fees higher)
- The 3rd graph is the balance multiplier, cheap when the balance is on our side, expensive when mostly on the peer's side
- The 4th graph is the "price experiment" w/ the 5 "cards" ... it modulates the price and then gradient walks to the best earnings for the channel
- The 5th graph is the output fees that we set publicly.  You can see how they are the multiplicative combination of the components
- The 6th graph shows the daily earnings from incoming and outgoing traffic on this channel
 

CodeRabbit sez:
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds contrib/fee-log-parser: a resilient Python DEBUG-log postprocessor that extracts baseline/size/balance/price/setchannel events, maintains per-peer state, deduplicates, computes multiplicative fee estimates (est_base/est_ppm), and persists structured records to a SQLite DB (peers + fee_change_events) or streams CSV; timestamps normalized to UTC and parser tolerant of varied JSON/escaped payloads and timestamp formats.
- Adds contrib/plot-fees and contrib/plot-aggregate: CLI plotting utilities that read the fee-log-parser SQLite output to produce per-peer multi-panel time-series and cohort-percentile aggregate plots (views: price level, baseline/base-ppm, size multiplier, balance multiplier, advertised fees, earnings, combo), with CSV/PNG export, time filtering, and optional lightning-cli integration for earnings/node/SCID resolution; includes extensive plotting helpers (log/symlog handling, tick formatting, axis padding).
- Updates contrib/README.md to document the new scripts (fee-log-parser, plot-fees, plot-aggregate), their CLI options, supported views/outputs, and the end-to-end pipeline (logs → SQLite/CSV → plots).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->