### PR TITLE
Add "all" (by_node) mode to clboss-earnings-history API

### DIFF
--- a/Boss/Mod/EarningsTracker.cpp
+++ b/Boss/Mod/EarningsTracker.cpp
@@ -614,10 +614,8 @@ private:
 		                   out_expenditures,
 		                   out_rebalanced
 		              FROM "EarningsTracker"
+			     ORDER BY time_bucket, node;
 		        )QRY";
-			if (!nodeid.empty())
-				sql += " WHERE node = :nodeid";
-			sql += " ORDER BY time_bucket, node;";
 		} else if (nodeid.empty()) {
 		        sql = R"QRY(
 		            SELECT time_bucket,

--- a/README.md
+++ b/README.md
@@ -550,7 +550,8 @@ The following commands have been added to observe the new data:
   - **Arguments**:
     - `nodeid` (optional): Limits the history to a particular node if
       provided. Without this argument, the history is accumulated
-      across all peers.
+      across all peers. Use `all` to return per-node buckets; each
+      history entry then includes a `node` field.
   - **Output**: 
     - The history consists of an array of records showing the earnings
       and expenditures for each day.

--- a/tests/boss/test_earningshistory.cpp
+++ b/tests/boss/test_earningshistory.cpp
@@ -156,6 +156,49 @@ int main() {
                         )JSON"));
 		return Ev::lift();
 	}).then([&]() {
+		// Check history for all peers, per-node rows
+		++req_id;
+		return bus.raise(Boss::Msg::CommandRequest{
+				"clboss-earnings-history",
+				Jsmn::Object::parse_json(R"JSON(["all"])JSON"),
+				Ln::CommandId::left(req_id)
+			});
+	}).then([&]() {
+		// std::cerr << lastRsp.response.output() << std::endl;
+		assert(rsp);
+		assert(lastRsp.id == Ln::CommandId::left(req_id));
+		auto result = Jsmn::Object::parse_json(lastRsp.response.output().c_str());
+		assert(result["history"].size() == 127);
+		assert(result["history"][0] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "bucket_time": 1722902400,
+			  "node": "020000000000000000000000000000000000000000000000000000000000000001",
+			  "in_earnings": 48000,
+			  "in_expenditures": 0,
+			  "out_earnings": 0,
+			  "out_expenditures": 0,
+			  "in_forwarded": 24000000,
+			  "in_rebalanced": 0,
+			  "out_forwarded": 0,
+			  "out_rebalanced": 0
+			}
+                )JSON"));
+		assert(result["history"][126] == Jsmn::Object::parse_json(R"JSON(
+			{
+			  "bucket_time": 1728000000,
+			  "node": "020000000000000000000000000000000000000000000000000000000000000003",
+			  "in_earnings": 0,
+			  "in_expenditures": 1000,
+			  "out_earnings": 0,
+			  "out_expenditures": 0,
+			  "in_forwarded": 0,
+			  "in_rebalanced": 1000000,
+			  "out_forwarded": 0,
+			  "out_rebalanced": 0
+			}
+                )JSON"));
+		return Ev::lift();
+	}).then([&]() {
 		// Check history for peer A
 		++req_id;
 		return bus.raise(Boss::Msg::CommandRequest{


### PR DESCRIPTION
Needed for the aggregate (percentile) view of earnings history #291 

Previously the `clboss-earnings-history` API either returned:
1. node-id specific data by day (when node_id is specified)
2. the sum of earnings for all nodes for each day (when node_id is not specified)

This PR adds a special node_id arg "all" which reports data for all node_ids but preserves the per-node records ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Adds "all" (by_node) mode to clboss-earnings-history: nodeid == "all" returns per-node daily buckets (preserving individual node records) instead of collapsing earnings into a single summed daily value.
- Implementation: introduces a by_node flag threaded into earnings_history_report (signature updated), adjusts SQL to select/order by time_bucket and node when by_node is true, and includes a node field in each JSON history entry; also enforces that by_node requires an empty node_id.
- Docs & tests: README updated to document the "all" behavior and a new test validates per-node history output (127 entries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->