### PR TITLE
Add Fee Monitor to Record Per-Channel Stats

### DIFF
--- a/Boss/Mod/ChannelFeeSetter.cpp
+++ b/Boss/Mod/ChannelFeeSetter.cpp
@@ -1,5 +1,6 @@
 #include"Boss/Mod/ChannelFeeSetter.hpp"
 #include"Boss/Mod/Rpc.hpp"
+#include"Boss/Msg/MonitorFeeSetChannel.hpp"
 #include"Boss/Msg/Init.hpp"
 #include"Boss/Msg/AvailableRpcCommands.hpp"
 #include"Boss/Msg/ProvideUnmanagement.hpp"
@@ -7,6 +8,7 @@
 #include"Boss/concurrent.hpp"
 #include"Boss/log.hpp"
 #include"Ev/Io.hpp"
+#include"Ev/coroutine.hpp"
 #include"Ev/foreach.hpp"
 #include"Jsmn/Object.hpp"
 #include"Json/Out.hpp"
@@ -56,14 +58,16 @@ void ChannelFeeSetter::start() {
 }
 
 Ev::Io<void> ChannelFeeSetter::set(Msg::SetChannelFee const& m) {
-	if (unmanaged.count(m.node) != 0)
-		return Boss::log( bus, Debug
-				, "ChannelFeeSetter: %s not managed by \"lnfee\"; "
-				  "would have set b=%" PRIu32 ", p=%" PRIu32 "."
-				, std::string(m.node).c_str()
-				, m.base
-				, m.proportional
-				);
+	if (unmanaged.count(m.node) != 0) {
+		co_await Boss::log( bus, Debug
+				  , "ChannelFeeSetter: %s not managed by \"lnfee\"; "
+				    "would have set b=%" PRIu32 ", p=%" PRIu32 "."
+				  , std::string(m.node).c_str()
+				  , m.base
+				  , m.proportional
+				  );
+		co_return;
+	}
 
 	auto parms = Json::Out()
 		.start_object()
@@ -71,18 +75,23 @@ Ev::Io<void> ChannelFeeSetter::set(Msg::SetChannelFee const& m) {
 			.field(have_setchannel ? "feebase" : "base", m.base)
 			.field(have_setchannel ? "feeppm" : "ppm", m.proportional)
 		.end_object();
-	return rpc->command(have_setchannel ? "setchannel" : "setchannelfee", std::move(parms)
-			   ).then([](Jsmn::Object res) {
-		return Ev::lift();
-	}).catching<RpcError>([](RpcError const& _) {
+	try {
+		co_await rpc->command(have_setchannel ? "setchannel" : "setchannelfee"
+				    , std::move(parms));
+		co_await bus.raise(Msg::MonitorFeeSetChannel{
+			m.node,
+			m.base,
+			m.proportional
+		});
+	} catch (RpcError const&) {
 		/* Ignore errors - there is race condition between
 		 * when we think we still have a peer, and that
 		 * peer closing the channel on us while we were
 		 * doing processing that eventually triggers this
 		 * module.
 		 */
-		return Ev::lift();
-	});
+	}
+	co_return;
 }
 
 }}

--- a/Boss/Mod/ChannelFeeSetter.cpp
+++ b/Boss/Mod/ChannelFeeSetter.cpp
@@ -78,11 +78,9 @@ Ev::Io<void> ChannelFeeSetter::set(Msg::SetChannelFee const& m) {
 	try {
 		co_await rpc->command(have_setchannel ? "setchannel" : "setchannelfee"
 				    , std::move(parms));
-		co_await bus.raise(Msg::MonitorFeeSetChannel{
-			m.node,
-			m.base,
-			m.proportional
-		});
+		// Don't use aggregate temporaries in a `co_await`, see docs/COROUTINE.md
+		Msg::MonitorFeeSetChannel msg{m.node, m.base, m.proportional};
+		co_await bus.raise(std::move(msg));
 	} catch (RpcError const&) {
 		/* Ignore errors - there is race condition between
 		 * when we think we still have a peer, and that

--- a/Boss/Mod/FeeModderByPriceTheory.cpp
+++ b/Boss/Mod/FeeModderByPriceTheory.cpp
@@ -1,5 +1,6 @@
 #include"Boss/Mod/FeeModderByPriceTheory.hpp"
 #include"Boss/Msg/DbResource.hpp"
+#include"Boss/Msg/MonitorFeeByTheory.hpp"
 #include"Boss/Msg/ForwardFee.hpp"
 #include"Boss/Msg/ListpeersAnalyzedResult.hpp"
 #include"Boss/Msg/ProvideChannelFeeModifier.hpp"
@@ -228,6 +229,7 @@ private:
 		auto os = std::ostringstream();
 
 		auto price = get_price(tx, node, os);
+		auto cards_left = get_cards_left(tx, node);
 		tx.commit();
 
 		mult = price_to_multiplier(price);
@@ -241,6 +243,9 @@ private:
 				  , mult
 				  , os.str().c_str()
 				  );
+		co_await bus.raise(Msg::MonitorFeeByTheory{
+			node, price, mult, cards_left
+		});
 		co_return mult;
 	}
 
@@ -266,6 +271,21 @@ private:
 		msg << "; ";
 		draw_a_card(tx, node, msg);
 		return get_price(tx, node, msg);
+	}
+	std::uint32_t get_cards_left(Sqlite3::Tx& tx, Ln::NodeId const& node) {
+		auto fetch = tx.query(R"QRY(
+		SELECT COUNT(*) FROM "FeeModderByPriceTheory_cards"
+		 WHERE node = :node
+		   AND pos = :CardPos_Deck
+		     ;
+		)QRY")
+			.bind(":node", std::string(node))
+			.bind(":CardPos_Deck", int(CardPos_Deck))
+			.execute()
+			;
+		for (auto& r : fetch)
+			return r.get<std::uint64_t>(0);
+		return 0;
 	}
 	void draw_a_card( Sqlite3::Tx& tx, Ln::NodeId const& node
 			, std::ostringstream& msg

--- a/Boss/Mod/FeeModderByPriceTheory.cpp
+++ b/Boss/Mod/FeeModderByPriceTheory.cpp
@@ -243,9 +243,9 @@ private:
 				  , mult
 				  , os.str().c_str()
 				  );
-		co_await bus.raise(Msg::MonitorFeeByTheory{
-			node, price, mult, cards_left
-		});
+		// Don't use aggregate temporaries in a `co_await`, see docs/COROUTINE.md
+		Msg::MonitorFeeByTheory msg{node, price, mult, cards_left};
+		co_await bus.raise(std::move(msg));
 		co_return mult;
 	}
 

--- a/Boss/Mod/FeeModderBySize.cpp
+++ b/Boss/Mod/FeeModderBySize.cpp
@@ -3,6 +3,7 @@
 #include"Boss/Msg/Init.hpp"
 #include"Boss/Msg/ChannelCreation.hpp"
 #include"Boss/Msg/ChannelDestruction.hpp"
+#include"Boss/Msg/MonitorFeeBySize.hpp"
 #include"Boss/Msg/ProvideChannelFeeModifier.hpp"
 #include"Boss/Msg/SolicitChannelFeeModifier.hpp"
 #include"Boss/Msg/TimerRandomDaily.hpp"
@@ -22,6 +23,7 @@
 #include"Util/stringify.hpp"
 #include<algorithm>
 #include<assert.h>
+#include<cstdint>
 #include<map>
 #include<math.h>
 #include<set>
@@ -353,7 +355,14 @@ private:
 			return Boss::log( bus, Info
 					, "FeeModderBySize: %s"
 					, os.str().c_str()
-					).then([multiplier]() {
+					).then([this, peer, total, worse, multiplier]() {
+				return bus.raise(Msg::MonitorFeeBySize{
+					peer,
+					std::uint64_t(total),
+					std::uint64_t(worse),
+					multiplier
+				});
+			}).then([multiplier]() {
 				return Ev::lift(multiplier);
 			});
 		});

--- a/Boss/Mod/FeeMonitor.cpp
+++ b/Boss/Mod/FeeMonitor.cpp
@@ -114,13 +114,15 @@ void FeeMonitor::start() {
 			"nodeid [since] [before]",
 			"Show fee modifier history for nodeid between since and before.",
 			false
+		}) + bus.raise(Msg::ManifestCommand{
+			"clboss-feemon-peers",
+			"[since] [before]",
+			"Show peer nodeids that have fee modifier history between since and before.",
+			false
 		});
 	});
 	bus.subscribe<Msg::CommandRequest
 		     >([this](Msg::CommandRequest const& req) {
-		if (req.command != "clboss-feemon-history")
-			return Ev::lift();
-
 		auto id = req.id;
 		auto paramfail = [this, id]() {
 			return bus.raise(Msg::CommandFail{
@@ -130,143 +132,208 @@ void FeeMonitor::start() {
 			});
 		};
 
-		auto nodeid_j = Jsmn::Object();
-		auto since_j = Jsmn::Object();
-		auto before_j = Jsmn::Object();
-		auto params = req.params;
-		if (params.is_object()) {
-			auto has_nodeid = params.has("nodeid");
-			auto has_since = params.has("since");
-			auto has_before = params.has("before");
-			if (!has_nodeid)
+		if (req.command == "clboss-feemon-history") {
+			auto nodeid_j = Jsmn::Object();
+			auto since_j = Jsmn::Object();
+			auto before_j = Jsmn::Object();
+			auto params = req.params;
+			if (params.is_object()) {
+				auto has_nodeid = params.has("nodeid");
+				auto has_since = params.has("since");
+				auto has_before = params.has("before");
+				if (!has_nodeid)
+					return paramfail();
+				if (params.size() != std::size_t(
+					has_nodeid + has_since + has_before
+				))
+					return paramfail();
+				nodeid_j = params["nodeid"];
+				if (has_since)
+					since_j = params["since"];
+				if (has_before)
+					before_j = params["before"];
+			} else if (params.is_array()) {
+				if (params.size() < 1 || params.size() > 3)
+					return paramfail();
+				nodeid_j = params[0];
+				if (params.size() >= 2)
+					since_j = params[1];
+				if (params.size() >= 3)
+					before_j = params[2];
+			} else {
 				return paramfail();
-			if (params.size() != std::size_t(
-				has_nodeid + has_since + has_before
-			))
+			}
+
+			if (!nodeid_j.is_string())
 				return paramfail();
-			nodeid_j = params["nodeid"];
-			if (has_since)
-				since_j = params["since"];
-			if (has_before)
-				before_j = params["before"];
-		} else if (params.is_array()) {
-			if (params.size() < 1 || params.size() > 3)
+			auto nodeid_s = std::string(nodeid_j);
+			if (!Ln::NodeId::valid_string(nodeid_s))
 				return paramfail();
-			nodeid_j = params[0];
-			if (params.size() >= 2)
-				since_j = params[1];
-			if (params.size() >= 3)
-				before_j = params[2];
-		} else {
-			return paramfail();
+			nodeid_s = std::string(Ln::NodeId(nodeid_s));
+
+			auto since = std::optional<double>();
+			auto before = std::optional<double>();
+			if (!parse_optional_number(since_j, since))
+				return paramfail();
+			if (!parse_optional_number(before_j, before))
+				return paramfail();
+			if (since && before && *since > *before)
+				return paramfail();
+
+			return db_transact().then([this, id, nodeid_s, since, before](Sqlite3::Tx tx) {
+				auto q = tx.query(R"QRY(
+				SELECT e.id,
+				       e.ts,
+				       e.peer_id,
+				       e.set_base,
+				       e.set_base IS NULL,
+				       e.set_ppm,
+				       e.set_ppm IS NULL,
+				       e.baseline_base,
+				       e.baseline_base IS NULL,
+				       e.baseline_ppm,
+				       e.baseline_ppm IS NULL,
+				       e.size_mult,
+				       e.size_mult IS NULL,
+				       e.size_total_peers,
+				       e.size_total_peers IS NULL,
+				       e.size_less_peers,
+				       e.size_less_peers IS NULL,
+				       e.balance_mult,
+				       e.balance_mult IS NULL,
+				       e.balance_our_msat,
+				       e.balance_our_msat IS NULL,
+				       e.balance_total_msat,
+				       e.balance_total_msat IS NULL,
+				       e.price_level,
+				       e.price_level IS NULL,
+				       e.price_mult,
+				       e.price_mult IS NULL,
+				       e.price_cards_left,
+				       e.price_cards_left IS NULL,
+				       e.price_center,
+				       e.price_center IS NULL,
+				       e.mult_product,
+				       e.mult_product IS NULL,
+				       e.est_base,
+				       e.est_base IS NULL,
+				       e.est_ppm,
+				       e.est_ppm IS NULL
+				  FROM feemon_change_events e
+				  JOIN feemon_peers p
+				    ON e.peer_id = p.id
+				 WHERE p.node_id = :node_id
+				   AND (:since IS NULL OR e.ts >= :since)
+				   AND (:before IS NULL OR e.ts <= :before)
+				 ORDER BY e.ts ASC;
+				)QRY");
+				q.bind(":node_id", nodeid_s);
+				bind_optional(q, ":since", since);
+				bind_optional(q, ":before", before);
+				auto fetch = q.execute();
+
+				auto out = Json::Out();
+				auto top = out.start_object();
+				top.field("nodeid", nodeid_s);
+				if (since)
+					top.field("since", *since);
+				if (before)
+					top.field("before", *before);
+				auto history = top.start_array("history");
+				for (auto& r : fetch) {
+					auto row = history.start_object();
+					auto idx = std::size_t(0);
+					row.field("id", r.get<std::uint64_t>(idx++));
+					row.field("ts", static_cast<std::uint64_t>(r.get<double>(idx++)));
+					row.field("peer_id", r.get<std::uint64_t>(idx++));
+					add_optional_int(row, "set_base", r, idx);
+					add_optional_int(row, "set_ppm", r, idx);
+					add_optional_int(row, "baseline_base", r, idx);
+					add_optional_int(row, "baseline_ppm", r, idx);
+					add_optional_double(row, "size_mult", r, idx);
+					add_optional_int(row, "size_total_peers", r, idx);
+					add_optional_int(row, "size_less_peers", r, idx);
+					add_optional_double(row, "balance_mult", r, idx);
+					add_optional_int(row, "balance_our_msat", r, idx);
+					add_optional_int(row, "balance_total_msat", r, idx);
+					add_optional_int(row, "price_level", r, idx);
+					add_optional_double(row, "price_mult", r, idx);
+					add_optional_int(row, "price_cards_left", r, idx);
+					add_optional_int(row, "price_center", r, idx);
+					add_optional_double(row, "mult_product", r, idx);
+					add_optional_int(row, "est_base", r, idx);
+					add_optional_int(row, "est_ppm", r, idx);
+					row.end_object();
+				}
+				history.end_array();
+				top.end_object();
+				tx.commit();
+				return bus.raise(Msg::CommandResponse{id, out});
+			});
+		} else if (req.command == "clboss-feemon-peers") {
+			auto since_j = Jsmn::Object();
+			auto before_j = Jsmn::Object();
+			auto params = req.params;
+			if (params.is_object()) {
+				auto has_since = params.has("since");
+				auto has_before = params.has("before");
+				if (params.size() != std::size_t(has_since + has_before))
+					return paramfail();
+				if (has_since)
+					since_j = params["since"];
+				if (has_before)
+					before_j = params["before"];
+			} else if (params.is_array()) {
+				if (params.size() > 2)
+					return paramfail();
+				if (params.size() >= 1)
+					since_j = params[0];
+				if (params.size() >= 2)
+					before_j = params[1];
+			} else if (!params.is_null()) {
+				return paramfail();
+			}
+
+			auto since = std::optional<double>();
+			auto before = std::optional<double>();
+			if (!parse_optional_number(since_j, since))
+				return paramfail();
+			if (!parse_optional_number(before_j, before))
+				return paramfail();
+			if (since && before && *since > *before)
+				return paramfail();
+
+			return db_transact().then([this, id, since, before](Sqlite3::Tx tx) {
+				auto q = tx.query(R"QRY(
+				SELECT DISTINCT p.node_id
+				  FROM feemon_change_events e
+				  JOIN feemon_peers p
+				    ON e.peer_id = p.id
+				 WHERE (:since IS NULL OR e.ts >= :since)
+				   AND (:before IS NULL OR e.ts <= :before)
+				 ORDER BY p.node_id ASC;
+				)QRY");
+				bind_optional(q, ":since", since);
+				bind_optional(q, ":before", before);
+				auto fetch = q.execute();
+
+				auto out = Json::Out();
+				auto top = out.start_object();
+				if (since)
+					top.field("since", *since);
+				if (before)
+					top.field("before", *before);
+				auto peers = top.start_array("peers");
+				for (auto& r : fetch)
+					peers.entry(r.get<std::string>(0));
+				peers.end_array();
+				top.end_object();
+				tx.commit();
+				return bus.raise(Msg::CommandResponse{id, out});
+			});
 		}
 
-		if (!nodeid_j.is_string())
-			return paramfail();
-		auto nodeid_s = std::string(nodeid_j);
-		if (!Ln::NodeId::valid_string(nodeid_s))
-			return paramfail();
-		nodeid_s = std::string(Ln::NodeId(nodeid_s));
-
-		auto since = std::optional<double>();
-		auto before = std::optional<double>();
-		if (!parse_optional_number(since_j, since))
-			return paramfail();
-		if (!parse_optional_number(before_j, before))
-			return paramfail();
-		if (since && before && *since > *before)
-			return paramfail();
-
-		return db_transact().then([this, id, nodeid_s, since, before](Sqlite3::Tx tx) {
-			auto q = tx.query(R"QRY(
-			SELECT e.id,
-			       e.ts,
-			       e.peer_id,
-			       e.set_base,
-			       e.set_base IS NULL,
-			       e.set_ppm,
-			       e.set_ppm IS NULL,
-			       e.baseline_base,
-			       e.baseline_base IS NULL,
-			       e.baseline_ppm,
-			       e.baseline_ppm IS NULL,
-			       e.size_mult,
-			       e.size_mult IS NULL,
-			       e.size_total_peers,
-			       e.size_total_peers IS NULL,
-			       e.size_less_peers,
-			       e.size_less_peers IS NULL,
-			       e.balance_mult,
-			       e.balance_mult IS NULL,
-			       e.balance_our_msat,
-			       e.balance_our_msat IS NULL,
-			       e.balance_total_msat,
-			       e.balance_total_msat IS NULL,
-			       e.price_level,
-			       e.price_level IS NULL,
-			       e.price_mult,
-			       e.price_mult IS NULL,
-			       e.price_cards_left,
-			       e.price_cards_left IS NULL,
-			       e.price_center,
-			       e.price_center IS NULL,
-			       e.mult_product,
-			       e.mult_product IS NULL,
-			       e.est_base,
-			       e.est_base IS NULL,
-			       e.est_ppm,
-			       e.est_ppm IS NULL
-			  FROM feemon_change_events e
-			  JOIN feemon_peers p
-			    ON e.peer_id = p.id
-			 WHERE p.node_id = :node_id
-			   AND (:since IS NULL OR e.ts >= :since)
-			   AND (:before IS NULL OR e.ts <= :before)
-			 ORDER BY e.ts ASC;
-			)QRY");
-			q.bind(":node_id", nodeid_s);
-			bind_optional(q, ":since", since);
-			bind_optional(q, ":before", before);
-			auto fetch = q.execute();
-
-			auto out = Json::Out();
-			auto top = out.start_object();
-			top.field("nodeid", nodeid_s);
-			if (since)
-				top.field("since", *since);
-			if (before)
-				top.field("before", *before);
-			auto history = top.start_array("history");
-			for (auto& r : fetch) {
-				auto row = history.start_object();
-				auto idx = std::size_t(0);
-				row.field("id", r.get<std::uint64_t>(idx++));
-				row.field("ts", static_cast<std::uint64_t>(r.get<double>(idx++)));
-				row.field("peer_id", r.get<std::uint64_t>(idx++));
-				add_optional_int(row, "set_base", r, idx);
-				add_optional_int(row, "set_ppm", r, idx);
-				add_optional_int(row, "baseline_base", r, idx);
-				add_optional_int(row, "baseline_ppm", r, idx);
-				add_optional_double(row, "size_mult", r, idx);
-				add_optional_int(row, "size_total_peers", r, idx);
-				add_optional_int(row, "size_less_peers", r, idx);
-				add_optional_double(row, "balance_mult", r, idx);
-				add_optional_int(row, "balance_our_msat", r, idx);
-				add_optional_int(row, "balance_total_msat", r, idx);
-				add_optional_int(row, "price_level", r, idx);
-				add_optional_double(row, "price_mult", r, idx);
-				add_optional_int(row, "price_cards_left", r, idx);
-				add_optional_int(row, "price_center", r, idx);
-				add_optional_double(row, "mult_product", r, idx);
-				add_optional_int(row, "est_base", r, idx);
-				add_optional_int(row, "est_ppm", r, idx);
-				row.end_object();
-			}
-			history.end_array();
-			top.end_object();
-			tx.commit();
-			return bus.raise(Msg::CommandResponse{id, out});
-		});
+		return Ev::lift();
 	});
 }
 

--- a/Boss/Mod/FeeMonitor.cpp
+++ b/Boss/Mod/FeeMonitor.cpp
@@ -208,6 +208,8 @@ void FeeMonitor::start() {
 			       e.price_mult IS NULL,
 			       e.price_cards_left,
 			       e.price_cards_left IS NULL,
+			       e.price_center,
+			       e.price_center IS NULL,
 			       e.mult_product,
 			       e.mult_product IS NULL,
 			       e.est_base,
@@ -254,6 +256,7 @@ void FeeMonitor::start() {
 				add_optional_int(row, "price_level", r, idx);
 				add_optional_double(row, "price_mult", r, idx);
 				add_optional_int(row, "price_cards_left", r, idx);
+				add_optional_int(row, "price_center", r, idx);
 				add_optional_double(row, "mult_product", r, idx);
 				add_optional_int(row, "est_base", r, idx);
 				add_optional_int(row, "est_ppm", r, idx);
@@ -297,6 +300,7 @@ Ev::Io<void> FeeMonitor::initialize_db() {
 		price_level INTEGER,
 		price_mult REAL,
 		price_cards_left INTEGER,
+		price_center INTEGER,
 		mult_product REAL,
 		est_base INTEGER,
 		est_ppm INTEGER,
@@ -375,6 +379,7 @@ FeeMonitor::on_price(Msg::MonitorFeeByTheory const& m) {
 	info.price_level = m.level;
 	info.price_mult = m.mult;
 	info.price_cards_left = m.cards_left;
+	info.price_center = m.center;
 	co_return;
 }
 
@@ -427,6 +432,7 @@ FeeMonitor::on_set(Msg::MonitorFeeSetChannel const& m) {
 		price_level,
 		price_mult,
 		price_cards_left,
+		price_center,
 		mult_product,
 		est_base,
 		est_ppm
@@ -446,6 +452,7 @@ FeeMonitor::on_set(Msg::MonitorFeeSetChannel const& m) {
 		:price_level,
 		:price_mult,
 		:price_cards_left,
+		:price_center,
 		:mult_product,
 		:est_base,
 		:est_ppm
@@ -467,6 +474,7 @@ FeeMonitor::on_set(Msg::MonitorFeeSetChannel const& m) {
 	bind_optional(q, ":price_level", snapshot.price_level);
 	bind_optional(q, ":price_mult", snapshot.price_mult);
 	bind_optional(q, ":price_cards_left", snapshot.price_cards_left);
+	bind_optional(q, ":price_center", snapshot.price_center);
 	bind_optional(q, ":mult_product", mult_product);
 	bind_optional(q, ":est_base", est_base);
 	bind_optional(q, ":est_ppm", est_ppm);

--- a/Boss/Mod/FeeMonitor.cpp
+++ b/Boss/Mod/FeeMonitor.cpp
@@ -1,0 +1,483 @@
+#include"Boss/Mod/FeeMonitor.hpp"
+#include"Boss/Msg/ChannelDestruction.hpp"
+#include"Boss/Msg/CommandFail.hpp"
+#include"Boss/Msg/CommandRequest.hpp"
+#include"Boss/Msg/CommandResponse.hpp"
+#include"Boss/Msg/DbResource.hpp"
+#include"Boss/Msg/ManifestCommand.hpp"
+#include"Boss/Msg/Manifestation.hpp"
+#include"Boss/Msg/MonitorFeeByBalance.hpp"
+#include"Boss/Msg/MonitorFeeByTheory.hpp"
+#include"Boss/Msg/MonitorFeeSetChannel.hpp"
+#include"Boss/Msg/MonitorFeeBySize.hpp"
+#include"Boss/Msg/PeerMedianChannelFee.hpp"
+#include"Ev/Io.hpp"
+#include"Ev/coroutine.hpp"
+#include"Ev/now.hpp"
+#include"Ev/yield.hpp"
+#include"Json/Out.hpp"
+#include"S/Bus.hpp"
+#include"Sqlite3.hpp"
+#include<cmath>
+
+namespace {
+
+template<typename T>
+void bind_optional(Sqlite3::Query& q, char const* name
+		 , std::optional<T> const& value) {
+	if (value)
+		q.bind(name, *value);
+	else
+		q.bind(name, nullptr);
+}
+
+template<typename Obj>
+void add_optional_int( Obj& obj
+		     , char const* name
+		     , Sqlite3::Row& r
+		     , std::size_t& idx
+		     ) {
+	auto value = r.get<std::int64_t>(idx++);
+	auto is_null = r.get<int>(idx++) != 0;
+	if (is_null)
+		obj.field(name, nullptr);
+	else
+		obj.field(name, value);
+}
+
+template<typename Obj>
+void add_optional_double( Obj& obj
+			, char const* name
+			, Sqlite3::Row& r
+			, std::size_t& idx
+			) {
+	auto value = r.get<double>(idx++);
+	auto is_null = r.get<int>(idx++) != 0;
+	if (is_null)
+		obj.field(name, nullptr);
+	else
+		obj.field(name, value);
+}
+
+bool parse_optional_number( Jsmn::Object const& value
+			  , std::optional<double>& out
+			  ) {
+	if (value.is_null())
+		return true;
+	if (!value.is_number())
+		return false;
+	out = (double) value;
+	return true;
+}
+
+}
+
+namespace Boss { namespace Mod {
+
+void FeeMonitor::start() {
+	bus.subscribe<Msg::DbResource
+		     >([this](Msg::DbResource const& m) {
+		return on_db(m);
+	});
+	bus.subscribe<Msg::PeerMedianChannelFee
+		     >([this](Msg::PeerMedianChannelFee const& m) {
+		return on_baseline(m);
+	});
+	bus.subscribe<Msg::ChannelDestruction
+		     >([this](Msg::ChannelDestruction const& d) {
+		auto it = peers.find(d.peer);
+		if (it == peers.end())
+			return Ev::lift();
+		peers.erase(it);
+		return Ev::lift();
+	});
+	bus.subscribe<Msg::MonitorFeeBySize
+		     >([this](Msg::MonitorFeeBySize const& m) {
+		return on_size(m);
+	});
+	bus.subscribe<Msg::MonitorFeeByBalance
+		     >([this](Msg::MonitorFeeByBalance const& m) {
+		return on_balance(m);
+	});
+	bus.subscribe<Msg::MonitorFeeByTheory
+		     >([this](Msg::MonitorFeeByTheory const& m) {
+		return on_price(m);
+	});
+	bus.subscribe<Msg::MonitorFeeSetChannel
+		     >([this](Msg::MonitorFeeSetChannel const& m) {
+		return on_set(m);
+	});
+	bus.subscribe<Msg::Manifestation
+		     >([this](Msg::Manifestation const&) {
+		return bus.raise(Msg::ManifestCommand{
+			"clboss-feemon-history",
+			"nodeid [since] [before]",
+			"Show fee modifier history for nodeid between since and before.",
+			false
+		});
+	});
+	bus.subscribe<Msg::CommandRequest
+		     >([this](Msg::CommandRequest const& req) {
+		if (req.command != "clboss-feemon-history")
+			return Ev::lift();
+
+		auto id = req.id;
+		auto paramfail = [this, id]() {
+			return bus.raise(Msg::CommandFail{
+				id, -32602,
+				"Parameter failure",
+				Json::Out::empty_object()
+			});
+		};
+
+		auto nodeid_j = Jsmn::Object();
+		auto since_j = Jsmn::Object();
+		auto before_j = Jsmn::Object();
+		auto params = req.params;
+		if (params.is_object()) {
+			auto has_nodeid = params.has("nodeid");
+			auto has_since = params.has("since");
+			auto has_before = params.has("before");
+			if (!has_nodeid)
+				return paramfail();
+			if (params.size() != std::size_t(
+				has_nodeid + has_since + has_before
+			))
+				return paramfail();
+			nodeid_j = params["nodeid"];
+			if (has_since)
+				since_j = params["since"];
+			if (has_before)
+				before_j = params["before"];
+		} else if (params.is_array()) {
+			if (params.size() < 1 || params.size() > 3)
+				return paramfail();
+			nodeid_j = params[0];
+			if (params.size() >= 2)
+				since_j = params[1];
+			if (params.size() >= 3)
+				before_j = params[2];
+		} else {
+			return paramfail();
+		}
+
+		if (!nodeid_j.is_string())
+			return paramfail();
+		auto nodeid_s = std::string(nodeid_j);
+		if (!Ln::NodeId::valid_string(nodeid_s))
+			return paramfail();
+		nodeid_s = std::string(Ln::NodeId(nodeid_s));
+
+		auto since = std::optional<double>();
+		auto before = std::optional<double>();
+		if (!parse_optional_number(since_j, since))
+			return paramfail();
+		if (!parse_optional_number(before_j, before))
+			return paramfail();
+		if (since && before && *since > *before)
+			return paramfail();
+
+		return db_transact().then([this, id, nodeid_s, since, before](Sqlite3::Tx tx) {
+			auto q = tx.query(R"QRY(
+			SELECT e.id,
+			       e.ts,
+			       e.peer_id,
+			       e.set_base,
+			       e.set_base IS NULL,
+			       e.set_ppm,
+			       e.set_ppm IS NULL,
+			       e.baseline_base,
+			       e.baseline_base IS NULL,
+			       e.baseline_ppm,
+			       e.baseline_ppm IS NULL,
+			       e.size_mult,
+			       e.size_mult IS NULL,
+			       e.size_total_peers,
+			       e.size_total_peers IS NULL,
+			       e.size_less_peers,
+			       e.size_less_peers IS NULL,
+			       e.balance_mult,
+			       e.balance_mult IS NULL,
+			       e.balance_our_msat,
+			       e.balance_our_msat IS NULL,
+			       e.balance_total_msat,
+			       e.balance_total_msat IS NULL,
+			       e.price_level,
+			       e.price_level IS NULL,
+			       e.price_mult,
+			       e.price_mult IS NULL,
+			       e.price_cards_left,
+			       e.price_cards_left IS NULL,
+			       e.mult_product,
+			       e.mult_product IS NULL,
+			       e.est_base,
+			       e.est_base IS NULL,
+			       e.est_ppm,
+			       e.est_ppm IS NULL
+			  FROM feemon_change_events e
+			  JOIN feemon_peers p
+			    ON e.peer_id = p.id
+			 WHERE p.node_id = :node_id
+			   AND (:since IS NULL OR e.ts >= :since)
+			   AND (:before IS NULL OR e.ts <= :before)
+			 ORDER BY e.ts ASC;
+			)QRY");
+			q.bind(":node_id", nodeid_s);
+			bind_optional(q, ":since", since);
+			bind_optional(q, ":before", before);
+			auto fetch = q.execute();
+
+			auto out = Json::Out();
+			auto top = out.start_object();
+			top.field("nodeid", nodeid_s);
+			if (since)
+				top.field("since", *since);
+			if (before)
+				top.field("before", *before);
+			auto history = top.start_array("history");
+			for (auto& r : fetch) {
+				auto row = history.start_object();
+				auto idx = std::size_t(0);
+				row.field("id", r.get<std::uint64_t>(idx++));
+				row.field("ts", static_cast<std::uint64_t>(r.get<double>(idx++)));
+				row.field("peer_id", r.get<std::uint64_t>(idx++));
+				add_optional_int(row, "set_base", r, idx);
+				add_optional_int(row, "set_ppm", r, idx);
+				add_optional_int(row, "baseline_base", r, idx);
+				add_optional_int(row, "baseline_ppm", r, idx);
+				add_optional_double(row, "size_mult", r, idx);
+				add_optional_int(row, "size_total_peers", r, idx);
+				add_optional_int(row, "size_less_peers", r, idx);
+				add_optional_double(row, "balance_mult", r, idx);
+				add_optional_int(row, "balance_our_msat", r, idx);
+				add_optional_int(row, "balance_total_msat", r, idx);
+				add_optional_int(row, "price_level", r, idx);
+				add_optional_double(row, "price_mult", r, idx);
+				add_optional_int(row, "price_cards_left", r, idx);
+				add_optional_double(row, "mult_product", r, idx);
+				add_optional_int(row, "est_base", r, idx);
+				add_optional_int(row, "est_ppm", r, idx);
+				row.end_object();
+			}
+			history.end_array();
+			top.end_object();
+			tx.commit();
+			return bus.raise(Msg::CommandResponse{id, out});
+		});
+	});
+}
+
+Ev::Io<void> FeeMonitor::on_db(Msg::DbResource const& m) {
+	db = m.db;
+	co_await initialize_db();
+	co_return;
+}
+
+Ev::Io<void> FeeMonitor::initialize_db() {
+	auto tx = co_await db_transact();
+	tx.query_execute(R"QRY(
+	CREATE TABLE IF NOT EXISTS feemon_peers (
+		id INTEGER PRIMARY KEY,
+		node_id TEXT NOT NULL UNIQUE
+	);
+	CREATE TABLE IF NOT EXISTS feemon_change_events (
+		id INTEGER PRIMARY KEY,
+		ts REAL NOT NULL,
+		peer_id INTEGER NOT NULL,
+		set_base INTEGER,
+		set_ppm INTEGER,
+		baseline_base INTEGER,
+		baseline_ppm INTEGER,
+		size_mult REAL,
+		size_total_peers INTEGER,
+		size_less_peers INTEGER,
+		balance_mult REAL,
+		balance_our_msat INTEGER,
+		balance_total_msat INTEGER,
+		price_level INTEGER,
+		price_mult REAL,
+		price_cards_left INTEGER,
+		mult_product REAL,
+		est_base INTEGER,
+		est_ppm INTEGER,
+		FOREIGN KEY(peer_id) REFERENCES feemon_peers(id)
+	);
+	CREATE INDEX IF NOT EXISTS feemon_change_events_peer_ts_idx
+	ON feemon_change_events(peer_id, ts);
+	CREATE INDEX IF NOT EXISTS feemon_change_events_ts_peer_idx
+	ON feemon_change_events(ts, peer_id);
+	)QRY");
+	tx.commit();
+	co_return;
+}
+
+Ev::Io<Sqlite3::Tx> FeeMonitor::db_transact() {
+	while (!db) {
+		co_await Ev::yield();
+	}
+	co_return co_await db.transact();
+}
+
+std::uint64_t
+FeeMonitor::get_peer_id(Sqlite3::Tx& tx, Ln::NodeId const& node) {
+	auto fetch = tx.query(R"QRY(
+	SELECT id
+	  FROM feemon_peers
+	 WHERE node_id = :node_id
+	     ;
+	)QRY")
+		.bind(":node_id", std::string(node))
+		.execute()
+		;
+	for (auto& r : fetch)
+		return r.get<std::uint64_t>(0);
+
+	tx.query(R"QRY(
+	INSERT OR IGNORE INTO feemon_peers
+	VALUES(NULL, :node_id);
+	)QRY")
+		.bind(":node_id", std::string(node))
+		.execute()
+		;
+
+	return get_peer_id(tx, node);
+}
+
+Ev::Io<void>
+FeeMonitor::on_baseline(Msg::PeerMedianChannelFee const& m) {
+	auto& info = peers[m.node];
+	info.baseline_base = m.base;
+	info.baseline_ppm = m.proportional;
+	co_return;
+}
+
+Ev::Io<void>
+FeeMonitor::on_size(Msg::MonitorFeeBySize const& m) {
+	auto& info = peers[m.node];
+	info.size_mult = m.mult;
+	info.size_total_peers = m.total_peers;
+	info.size_less_peers = m.less_peers;
+	co_return;
+}
+
+Ev::Io<void>
+FeeMonitor::on_balance(Msg::MonitorFeeByBalance const& m) {
+	auto& info = peers[m.node];
+	info.balance_mult = m.mult;
+	info.balance_our_msat = m.our_msat;
+	info.balance_total_msat = m.total_msat;
+	co_return;
+}
+
+Ev::Io<void>
+FeeMonitor::on_price(Msg::MonitorFeeByTheory const& m) {
+	auto& info = peers[m.node];
+	info.price_level = m.level;
+	info.price_mult = m.mult;
+	info.price_cards_left = m.cards_left;
+	co_return;
+}
+
+Ev::Io<void>
+FeeMonitor::on_set(Msg::MonitorFeeSetChannel const& m) {
+	auto snapshot = peers[m.node];
+	auto ts = Ev::now();
+
+	auto mult_product = std::optional<double>();
+	auto est_base = std::optional<std::int64_t>();
+	auto est_ppm = std::optional<std::int64_t>();
+
+	if ( snapshot.baseline_base
+	  && snapshot.baseline_ppm
+	  && snapshot.size_mult
+	  && snapshot.balance_mult
+	  && snapshot.price_mult
+	   ) {
+		mult_product = (*snapshot.size_mult)
+			     * (*snapshot.balance_mult)
+			     * (*snapshot.price_mult);
+		auto base = std::llround(
+			double(*snapshot.baseline_base) * *mult_product
+		);
+		auto ppm = std::llround(
+			double(*snapshot.baseline_ppm) * *mult_product
+		);
+		if (ppm == 0)
+			ppm = 1;
+		est_base = base;
+		est_ppm = ppm;
+	}
+
+	auto tx = co_await db_transact();
+	auto peer_id = get_peer_id(tx, m.node);
+	auto q = tx.query(R"QRY(
+	INSERT INTO feemon_change_events (
+		ts,
+		peer_id,
+		set_base,
+		set_ppm,
+		baseline_base,
+		baseline_ppm,
+		size_mult,
+		size_total_peers,
+		size_less_peers,
+		balance_mult,
+		balance_our_msat,
+		balance_total_msat,
+		price_level,
+		price_mult,
+		price_cards_left,
+		mult_product,
+		est_base,
+		est_ppm
+	) VALUES (
+		:ts,
+		:peer_id,
+		:set_base,
+		:set_ppm,
+		:baseline_base,
+		:baseline_ppm,
+		:size_mult,
+		:size_total_peers,
+		:size_less_peers,
+		:balance_mult,
+		:balance_our_msat,
+		:balance_total_msat,
+		:price_level,
+		:price_mult,
+		:price_cards_left,
+		:mult_product,
+		:est_base,
+		:est_ppm
+	);
+	)QRY");
+
+	q.bind(":ts", ts)
+	 .bind(":peer_id", peer_id)
+	 .bind(":set_base", m.base)
+	 .bind(":set_ppm", m.proportional);
+	bind_optional(q, ":baseline_base", snapshot.baseline_base);
+	bind_optional(q, ":baseline_ppm", snapshot.baseline_ppm);
+	bind_optional(q, ":size_mult", snapshot.size_mult);
+	bind_optional(q, ":size_total_peers", snapshot.size_total_peers);
+	bind_optional(q, ":size_less_peers", snapshot.size_less_peers);
+	bind_optional(q, ":balance_mult", snapshot.balance_mult);
+	bind_optional(q, ":balance_our_msat", snapshot.balance_our_msat);
+	bind_optional(q, ":balance_total_msat", snapshot.balance_total_msat);
+	bind_optional(q, ":price_level", snapshot.price_level);
+	bind_optional(q, ":price_mult", snapshot.price_mult);
+	bind_optional(q, ":price_cards_left", snapshot.price_cards_left);
+	bind_optional(q, ":mult_product", mult_product);
+	bind_optional(q, ":est_base", est_base);
+	bind_optional(q, ":est_ppm", est_ppm);
+	q.execute();
+	tx.commit();
+	co_return;
+}
+
+FeeMonitor::FeeMonitor(S::Bus& bus_) : bus(bus_) {
+	start();
+}
+FeeMonitor::~FeeMonitor() =default;
+
+}}

--- a/Boss/Mod/FeeMonitor.hpp
+++ b/Boss/Mod/FeeMonitor.hpp
@@ -38,6 +38,7 @@ private:
 		std::optional<std::int64_t> price_level;
 		std::optional<double> price_mult;
 		std::optional<std::uint32_t> price_cards_left;
+		std::optional<std::int64_t> price_center;
 	};
 
 	S::Bus& bus;

--- a/Boss/Mod/FeeMonitor.hpp
+++ b/Boss/Mod/FeeMonitor.hpp
@@ -1,0 +1,71 @@
+#ifndef BOSS_MOD_FEEMONITOR_HPP
+#define BOSS_MOD_FEEMONITOR_HPP
+
+#include"Ln/NodeId.hpp"
+#include"Sqlite3/Db.hpp"
+#include<cstdint>
+#include<map>
+#include<optional>
+
+namespace Boss { namespace Msg { struct DbResource; }}
+namespace Boss { namespace Msg { struct MonitorFeeByBalance; }}
+namespace Boss { namespace Msg { struct MonitorFeeByTheory; }}
+namespace Boss { namespace Msg { struct MonitorFeeSetChannel; }}
+namespace Boss { namespace Msg { struct MonitorFeeBySize; }}
+namespace Boss { namespace Msg { struct PeerMedianChannelFee; }}
+namespace Ev { template<typename a> class Io; }
+namespace S { class Bus; }
+namespace Sqlite3 { class Tx; }
+
+namespace Boss { namespace Mod {
+
+/** class Boss::Mod::FeeMonitor
+ *
+ * @brief Collects fee-setting context and records fee changes
+ * into the internal sqlite database.
+ */
+class FeeMonitor {
+private:
+	struct PeerInfo {
+		std::optional<std::uint32_t> baseline_base;
+		std::optional<std::uint32_t> baseline_ppm;
+		std::optional<double> size_mult;
+		std::optional<std::uint64_t> size_total_peers;
+		std::optional<std::uint64_t> size_less_peers;
+		std::optional<double> balance_mult;
+		std::optional<std::uint64_t> balance_our_msat;
+		std::optional<std::uint64_t> balance_total_msat;
+		std::optional<std::int64_t> price_level;
+		std::optional<double> price_mult;
+		std::optional<std::uint32_t> price_cards_left;
+	};
+
+	S::Bus& bus;
+	Sqlite3::Db db;
+	std::map<Ln::NodeId, PeerInfo> peers;
+
+	void start();
+
+	Ev::Io<void> initialize_db();
+	Ev::Io<Sqlite3::Tx> db_transact();
+	std::uint64_t get_peer_id(Sqlite3::Tx& tx, Ln::NodeId const& node);
+
+	Ev::Io<void> on_db(Boss::Msg::DbResource const& m);
+	Ev::Io<void> on_baseline(Boss::Msg::PeerMedianChannelFee const& m);
+	Ev::Io<void> on_size(Boss::Msg::MonitorFeeBySize const& m);
+	Ev::Io<void> on_balance(Boss::Msg::MonitorFeeByBalance const& m);
+	Ev::Io<void> on_price(Boss::Msg::MonitorFeeByTheory const& m);
+	Ev::Io<void> on_set(Boss::Msg::MonitorFeeSetChannel const& m);
+
+public:
+	FeeMonitor(FeeMonitor const&) =delete;
+	FeeMonitor(FeeMonitor&&) =delete;
+
+	explicit
+	FeeMonitor(S::Bus& bus_);
+	~FeeMonitor();
+};
+
+}}
+
+#endif /* !defined(BOSS_MOD_FEEMONITOR_HPP) */

--- a/Boss/Mod/OnchainFundsAnnouncer.cpp
+++ b/Boss/Mod/OnchainFundsAnnouncer.cpp
@@ -96,7 +96,9 @@ Ev::Io<void> OnchainFundsAnnouncer::announce() {
 				    "onchain."
 				  , std::string(amount).c_str()
 				  );
-		co_await bus.raise(Msg::OnchainFunds{amount});
+		// Don't use aggregate temporaries in a `co_await`, see docs/COROUTINE.md
+		Msg::OnchainFunds msg{amount};
+		co_await bus.raise(std::move(msg));
 	} catch (RpcError const&) {
 		no_onchain_funds = true;
 	}

--- a/Boss/Mod/all.cpp
+++ b/Boss/Mod/all.cpp
@@ -27,6 +27,7 @@
 #include"Boss/Mod/EarningsRebalancer.hpp"
 #include"Boss/Mod/EarningsTracker.hpp"
 #include"Boss/Mod/FeeModderByBalance.hpp"
+#include"Boss/Mod/FeeMonitor.hpp"
 #include"Boss/Mod/FeeModderByPriceTheory.hpp"
 #include"Boss/Mod/FeeModderBySize.hpp"
 #include"Boss/Mod/ForwardFeeMonitor.hpp"
@@ -178,6 +179,7 @@ std::shared_ptr<void> all( std::ostream& cout
 	all->install<PaymentDeleter>(bus);
 
 	/* Channel fees.  */
+	all->install<FeeMonitor>(bus);
 	all->install<PeerCompetitorFeeMonitor::Main>(bus);
 	all->install<ChannelFeeSetter>(bus);
 	all->install<ChannelFeeManager>(bus);

--- a/Boss/Msg/MonitorFeeByBalance.hpp
+++ b/Boss/Msg/MonitorFeeByBalance.hpp
@@ -1,0 +1,23 @@
+#ifndef BOSS_MSG_MONITORFEEBYBALANCE_HPP
+#define BOSS_MSG_MONITORFEEBYBALANCE_HPP
+
+#include"Ln/NodeId.hpp"
+#include<cstdint>
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::MonitorFeeByBalance
+ *
+ * @brief informs the fee monitor of the balance-based
+ * fee multiplier for a peer.
+ */
+struct MonitorFeeByBalance {
+	Ln::NodeId node;
+	double mult;
+	std::uint64_t our_msat;
+	std::uint64_t total_msat;
+};
+
+}}
+
+#endif /* !defined(BOSS_MSG_MONITORFEEBYBALANCE_HPP) */

--- a/Boss/Msg/MonitorFeeBySize.hpp
+++ b/Boss/Msg/MonitorFeeBySize.hpp
@@ -1,0 +1,23 @@
+#ifndef BOSS_MSG_MONITORFEEBYSIZE_HPP
+#define BOSS_MSG_MONITORFEEBYSIZE_HPP
+
+#include"Ln/NodeId.hpp"
+#include<cstdint>
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::MonitorFeeBySize
+ *
+ * @brief informs the fee monitor of the size-based
+ * fee multiplier for a peer.
+ */
+struct MonitorFeeBySize {
+	Ln::NodeId node;
+	std::uint64_t total_peers;
+	std::uint64_t less_peers;
+	double mult;
+};
+
+}}
+
+#endif /* !defined(BOSS_MSG_MONITORFEEBYSIZE_HPP) */

--- a/Boss/Msg/MonitorFeeByTheory.hpp
+++ b/Boss/Msg/MonitorFeeByTheory.hpp
@@ -1,0 +1,24 @@
+#ifndef BOSS_MSG_MONITORFEEBYTHEORY_HPP
+#define BOSS_MSG_MONITORFEEBYTHEORY_HPP
+
+#include"Ln/NodeId.hpp"
+#include<cstdint>
+#include<optional>
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::MonitorFeeByTheory
+ *
+ * @brief informs the fee monitor of the price-theory
+ * fee level and multiplier for a peer.
+ */
+struct MonitorFeeByTheory {
+	Ln::NodeId node;
+	std::int64_t level;
+	double mult;
+	std::optional<std::uint32_t> cards_left;
+};
+
+}}
+
+#endif /* !defined(BOSS_MSG_MONITORFEEBYTHEORY_HPP) */

--- a/Boss/Msg/MonitorFeeByTheory.hpp
+++ b/Boss/Msg/MonitorFeeByTheory.hpp
@@ -16,6 +16,7 @@ struct MonitorFeeByTheory {
 	Ln::NodeId node;
 	std::int64_t level;
 	double mult;
+	std::int64_t center;
 	std::optional<std::uint32_t> cards_left;
 };
 

--- a/Boss/Msg/MonitorFeeSetChannel.hpp
+++ b/Boss/Msg/MonitorFeeSetChannel.hpp
@@ -1,0 +1,22 @@
+#ifndef BOSS_MSG_MONITORFEESETCHANNEL_HPP
+#define BOSS_MSG_MONITORFEESETCHANNEL_HPP
+
+#include"Ln/NodeId.hpp"
+#include<cstdint>
+
+namespace Boss { namespace Msg {
+
+/** struct Boss::Msg::MonitorFeeSetChannel
+ *
+ * @brief informs the fee monitor that fees were set
+ * for a peer.
+ */
+struct MonitorFeeSetChannel {
+	Ln::NodeId node;
+	std::uint32_t base;
+	std::uint32_t proportional;
+};
+
+}}
+
+#endif /* !defined(BOSS_MSG_MONITORFEESETCHANNEL_HPP) */

--- a/Makefile.am
+++ b/Makefile.am
@@ -149,6 +149,8 @@ libclboss_la_SOURCES = \
 	Boss/Mod/EarningsTracker.hpp \
 	Boss/Mod/FeeModderByBalance.cpp \
 	Boss/Mod/FeeModderByBalance.hpp \
+	Boss/Mod/FeeMonitor.cpp \
+	Boss/Mod/FeeMonitor.hpp \
 	Boss/Mod/FeeModderByPriceTheory.cpp \
 	Boss/Mod/FeeModderByPriceTheory.hpp \
 	Boss/Mod/FeeModderBySize.cpp \
@@ -291,6 +293,10 @@ libclboss_la_SOURCES = \
 	Boss/Msg/CommandRequest.hpp \
 	Boss/Msg/CommandResponse.hpp \
 	Boss/Msg/DbResource.hpp \
+	Boss/Msg/MonitorFeeByBalance.hpp \
+	Boss/Msg/MonitorFeeByTheory.hpp \
+	Boss/Msg/MonitorFeeSetChannel.hpp \
+	Boss/Msg/MonitorFeeBySize.hpp \
 	Boss/Msg/EndOfOptions.hpp \
 	Boss/Msg/ForwardFee.hpp \
 	Boss/Msg/Init.hpp \
@@ -599,6 +605,7 @@ TESTS = \
 	tests/boss/test_channelcreator_reprioritizer \
 	tests/boss/test_earningsrebalancer \
 	tests/boss/test_earningstracker \
+	tests/boss/test_feemon_history \
 	tests/boss/test_feemodderbypricetheory \
 	tests/boss/test_forwardfeemonitor \
 	tests/boss/test_getmanifest \

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ override the CLBOSS default via `CXXFLAGS`, such as:
 
     ./configure CXXFLAGS="-g -O2"  # or whatever flags you like
     ./configure CXXFLAGS="-g -Og"  # recommended for debugging
+    ./configure CXXFLAGS="-O1 -g -fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address" # useful for debugging heap issues
 
 And if your build machine has more than 1 core, you probably
 want to pass in the `-j` option to `make`, too:

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -81,6 +81,16 @@ how many days of earnings history are considered when ranking channels.
   `feemon_peers` and `feemon_change_events`) during normal operation.
 - **`clboss-feemon-history`** is a CLBOSS command that returns per-peer fee modifier
   history between optional `since`/`before` timestamps.
+- **`feemon-validate`** compares `fee-log-parser` sqlite history against
+  `clboss-feemon-history` per peer over a requested time window. It reports
+  per-peer progress, prints full-record diagnostics for mismatches, and exits
+  non-zero when discrepancies are found. Default external DB path is
+  `./clboss-fee-info.sqlite3` and default timestamp tolerance is 3 seconds.
+  Default float tolerance is `1e-5` and is scaled by value magnitude
+  (`tol * max(1, |a|, |b|)`) to avoid false mismatches from JSON float
+  rendering precision (notably `mult_product`).
+  `--since`/`--before` accept Unix epoch seconds in addition to the existing
+  human-readable time formats.
 - **`plot-fees`** plots fee-related time series from the `fee-log-parser` sqlite
   output. `--peer` accepts a nodeid, alias (via lightning-cli/listnodes), or
   SCID (via lightning-cli/listpeerchannels). The combo view includes a daily

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -83,14 +83,19 @@ how many days of earnings history are considered when ranking channels.
   history between optional `since`/`before` timestamps.
 - **`feemon-validate`** compares `fee-log-parser` sqlite history against
   `clboss-feemon-history` per peer over a requested time window. It reports
-  per-peer progress, prints full-record diagnostics for mismatches, and exits
+  per-peer progress, prints compact timestamp diagnostics for missing/extra
+  records, prints full-record diagnostics for field mismatches, and exits
   non-zero when discrepancies are found. Default external DB path is
-  `./clboss-fee-info.sqlite3` and default timestamp tolerance is 3 seconds.
+  `./clboss-fee-info.sqlite3` and default timestamp tolerance is 20 seconds.
   Default float tolerance is `1e-5` and is scaled by value magnitude
   (`tol * max(1, |a|, |b|)`) to avoid false mismatches from JSON float
   rendering precision (notably `mult_product`).
+  Derived integer fields `est_base` and `est_ppm` use a relative tolerance
+  with default `1e-3` (`--int-rel-tolerance`) so small rounding effects at
+  large magnitudes do not trigger mismatches.
   `--since`/`--before` accept Unix epoch seconds in addition to the existing
-  human-readable time formats.
+  human-readable time formats. Naive timestamps are interpreted in local time;
+  Unix epoch input is UTC; explicit timezone offsets are honored.
 - **`plot-fees`** plots fee-related time series from the `fee-log-parser` sqlite
   output. `--peer` accepts a nodeid, alias (via lightning-cli/listnodes), or
   SCID (via lightning-cli/listpeerchannels). The combo view includes a daily

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -76,7 +76,11 @@ how many days of earnings history are considered when ranking channels.
 - **`recently-closed`** lists channels that closed within the last N days, also
   controlled via `--days`.
 - **`fee-log-parser`** is a parser that streams DEBUG-level logging and writes
-  a sqlite database containing fee algorithm information.
+  a sqlite database containing fee algorithm information. CLBOSS now records
+  the same schema in its internal database (`data.clboss`, tables
+  `feemon_peers` and `feemon_change_events`) during normal operation.
+- **`clboss-feemon-history`** is a CLBOSS command that returns per-peer fee modifier
+  history between optional `since`/`before` timestamps.
 - **`plot-fees`** plots fee-related time series from the `fee-log-parser` sqlite
   output. `--peer` accepts a nodeid, alias (via lightning-cli/listnodes), or
   SCID (via lightning-cli/listpeerchannels). The combo view includes a daily

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -99,7 +99,8 @@ how many days of earnings history are considered when ranking channels.
 - **`plot-fees`** plots fee-related time series for a peer from merged fee monitor
   data: API history (`clboss-feemon-history`) plus legacy sqlite history
   (`fee-log-parser`). When both sources cover a period, API records are
-  preferred and sqlite is used only for earlier history. `--peer` accepts a
+  preferred and sqlite is used only for earlier history. By default it uses API
+  data only; pass `--db` to include legacy sqlite history. `--peer` accepts a
   nodeid, alias (via lightning-cli/listnodes), or SCID (via
   lightning-cli/listpeerchannels). The combo view includes a daily earnings
   panel (incoming/outgoing msat per day) when lightning-cli is available, and
@@ -109,7 +110,8 @@ how many days of earnings history are considered when ranking channels.
   `--title` to override the plot title (defaults to the peer label; pass empty
   to omit).
 - **`plot-aggregate`** plots aggregate percentile summaries from merged fee monitor
-  data (API preferred over overlapping legacy sqlite history). Views include
+  data (API preferred over overlapping legacy sqlite history). By default it
+  uses API data only; pass `--db` to include legacy sqlite history. Views include
   `baseline-base`, `baseline-ppm`, `size`, `balance`, `theory`,
   `advertised-base`, `advertised-ppm`, `earnings`, and a `combo` view. Each
   view shows daily

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -104,8 +104,10 @@ how many days of earnings history are considered when ranking channels.
   lightning-cli/listpeerchannels). The combo view includes a daily earnings
   panel (incoming/outgoing msat per day) when lightning-cli is available, and
   the `incoming-earnings`/`outgoing-earnings` views render those panels on
-  their own. Use `--title` to override the plot title (defaults to the peer
-  label; pass empty to omit).
+  their own. In the `theory` panel, a `theory_center` line is drawn only where
+  API records include `price_center`; legacy-only spans omit that line. Use
+  `--title` to override the plot title (defaults to the peer label; pass empty
+  to omit).
 - **`plot-aggregate`** plots aggregate percentile summaries from merged fee monitor
   data (API preferred over overlapping legacy sqlite history). Views include
   `baseline-base`, `baseline-ppm`, `size`, `balance`, `theory`,

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -96,15 +96,18 @@ how many days of earnings history are considered when ranking channels.
   `--since`/`--before` accept Unix epoch seconds in addition to the existing
   human-readable time formats. Naive timestamps are interpreted in local time;
   Unix epoch input is UTC; explicit timezone offsets are honored.
-- **`plot-fees`** plots fee-related time series from the `fee-log-parser` sqlite
-  output. `--peer` accepts a nodeid, alias (via lightning-cli/listnodes), or
-  SCID (via lightning-cli/listpeerchannels). The combo view includes a daily
-  earnings panel (incoming/outgoing msat per day) when lightning-cli is
-  available, and the `incoming-earnings`/`outgoing-earnings` views render
-  those panels on their own. Use `--title` to override the plot title
-  (defaults to the peer label; pass empty to omit).
-- **`plot-aggregate`** plots aggregate percentile summaries from the
-  `fee-log-parser` sqlite output. Views include
+- **`plot-fees`** plots fee-related time series for a peer from merged fee monitor
+  data: API history (`clboss-feemon-history`) plus legacy sqlite history
+  (`fee-log-parser`). When both sources cover a period, API records are
+  preferred and sqlite is used only for earlier history. `--peer` accepts a
+  nodeid, alias (via lightning-cli/listnodes), or SCID (via
+  lightning-cli/listpeerchannels). The combo view includes a daily earnings
+  panel (incoming/outgoing msat per day) when lightning-cli is available, and
+  the `incoming-earnings`/`outgoing-earnings` views render those panels on
+  their own. Use `--title` to override the plot title (defaults to the peer
+  label; pass empty to omit).
+- **`plot-aggregate`** plots aggregate percentile summaries from merged fee monitor
+  data (API preferred over overlapping legacy sqlite history). Views include
   `baseline-base`, `baseline-ppm`, `size`, `balance`, `theory`,
   `advertised-base`, `advertised-ppm`, `earnings`, and a `combo` view. Each
   view shows daily

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -86,7 +86,7 @@ how many days of earnings history are considered when ranking channels.
   per-peer progress, prints compact timestamp diagnostics for missing/extra
   records, prints full-record diagnostics for field mismatches, and exits
   non-zero when discrepancies are found. Default external DB path is
-  `./clboss-fee-info.sqlite3` and default timestamp tolerance is 20 seconds.
+  `./clboss-fee-info.sqlite3` and default timestamp tolerance is 60 seconds.
   Default float tolerance is `1e-5` and is scaled by value magnitude
   (`tol * max(1, |a|, |b|)`) to avoid false mismatches from JSON float
   rendering precision (notably `mult_product`).

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -119,4 +119,6 @@ how many days of earnings history are considered when ranking channels.
   view shows daily
   p00/p10/p25/p50/p75/p90/p100 percentiles across nodes. The `earnings`
   view uses `clboss-earnings-history all` to compute net earnings
-  percentiles (sat/day).
+  percentiles (sat/day). In API mode, peer discovery uses
+  `clboss-feemon-peers [since] [before]` so windowed aggregate plots include
+  peers that were active during the selected period (even if currently closed).

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -81,6 +81,8 @@ how many days of earnings history are considered when ranking channels.
   `feemon_peers` and `feemon_change_events`) during normal operation.
 - **`clboss-feemon-history`** is a CLBOSS command that returns per-peer fee modifier
   history between optional `since`/`before` timestamps.
+- **`clboss-feemon-peers`** is a CLBOSS command that returns peer nodeids with fee
+  monitor history between optional `since`/`before` timestamps.
 - **`feemon-validate`** compares `fee-log-parser` sqlite history against
   `clboss-feemon-history` per peer over a requested time window. It reports
   per-peer progress, prints compact timestamp diagnostics for missing/extra

--- a/contrib/feemon-validate
+++ b/contrib/feemon-validate
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import bisect
 import json
 import os
 import re
@@ -32,11 +33,15 @@ FLOAT_FIELDS = {
     "price_mult",
     "mult_product",
 }
+REL_INT_FIELDS = {
+    "est_base",
+    "est_ppm",
+}
 
 
 def normalize_dt(dt):
     if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=datetime.now().astimezone().tzinfo)
     return dt.astimezone(timezone.utc)
 
 
@@ -64,9 +69,9 @@ def parse_time_arg(value):
         }[unit]
         if sign == "-":
             delta = -delta
-        return normalize_dt(datetime.now(timezone.utc) + delta)
+        return normalize_dt(datetime.now().astimezone() + delta)
     if value.count(":") in (1, 2) and "T" not in value and "-" not in value:
-        today = datetime.now(timezone.utc).date().isoformat()
+        today = datetime.now().astimezone().date().isoformat()
         return normalize_dt(datetime.fromisoformat(f"{today}T{value}"))
     return normalize_dt(datetime.fromisoformat(value))
 
@@ -204,7 +209,7 @@ def make_norm_record(raw):
     return norm
 
 
-def field_equal(name, a, b, float_tol):
+def field_equal(name, a, b, float_tol, int_rel_tol):
     if a is None or b is None:
         return a is None and b is None
     if name in FLOAT_FIELDS:
@@ -212,49 +217,60 @@ def field_equal(name, a, b, float_tol):
         # For values near zero this is absolute tolerance, otherwise relative.
         scale = max(1.0, abs(float(a)), abs(float(b)))
         return abs(float(a) - float(b)) <= (float_tol * scale)
+    if name in REL_INT_FIELDS:
+        ai = int(a)
+        bi = int(b)
+        scale = max(1.0, abs(float(ai)), abs(float(bi)))
+        return abs(ai - bi) <= (int_rel_tol * scale)
     return int(a) == int(b)
 
 
-def fields_equal(ext_rec, int_rec, float_tol):
+def fields_equal(ext_rec, int_rec, float_tol, int_rel_tol):
     for name in COMMON_FIELDS:
-        if not field_equal(name, ext_rec["fields"][name], int_rec["fields"][name], float_tol):
+        if not field_equal(
+            name,
+            ext_rec["fields"][name],
+            int_rec["fields"][name],
+            float_tol,
+            int_rel_tol,
+        ):
             return False
     return True
 
 
-def record_match(ext_rec, int_rec, ts_tol, float_tol):
+def record_match(ext_rec, int_rec, ts_tol, float_tol, int_rel_tol):
     if abs(ext_rec["ts"] - int_rec["ts"]) > ts_tol:
         return False
-    return fields_equal(ext_rec, int_rec, float_tol)
+    return fields_equal(ext_rec, int_rec, float_tol, int_rel_tol)
 
 
-def find_internal_match(ext_rec, internal, start, lookahead, ts_tol, float_tol):
+def find_internal_match(ext_rec, internal, start, lookahead, ts_tol, float_tol, int_rel_tol):
     end = min(len(internal), start + lookahead + 1)
     for j in range(start + 1, end):
-        if record_match(ext_rec, internal[j], ts_tol, float_tol):
+        if record_match(ext_rec, internal[j], ts_tol, float_tol, int_rel_tol):
             return j
     return None
 
 
-def find_external_match(int_rec, external, start, lookahead, ts_tol, float_tol):
+def find_external_match(int_rec, external, start, lookahead, ts_tol, float_tol, int_rel_tol):
     end = min(len(external), start + lookahead + 1)
     for i in range(start + 1, end):
-        if record_match(external[i], int_rec, ts_tol, float_tol):
+        if record_match(external[i], int_rec, ts_tol, float_tol, int_rel_tol):
             return i
     return None
 
 
-def field_diffs(ext_rec, int_rec, float_tol):
+def field_diffs(ext_rec, int_rec, float_tol, int_rel_tol):
     diffs = []
     for name in COMMON_FIELDS:
         a = ext_rec["fields"][name]
         b = int_rec["fields"][name]
-        if not field_equal(name, a, b, float_tol):
+        if not field_equal(name, a, b, float_tol, int_rel_tol):
             diffs.append({"field": name, "external": a, "internal": b})
     return diffs
 
 
-def compare_peer(external, internal, ts_tol, float_tol, lookahead):
+def compare_peer(external, internal, ts_tol, float_tol, int_rel_tol, lookahead):
     matched = 0
     discrepancies = []
     i = 0
@@ -262,14 +278,18 @@ def compare_peer(external, internal, ts_tol, float_tol, lookahead):
     while i < len(external) and j < len(internal):
         ext_rec = external[i]
         int_rec = internal[j]
-        if record_match(ext_rec, int_rec, ts_tol, float_tol):
+        if record_match(ext_rec, int_rec, ts_tol, float_tol, int_rel_tol):
             matched += 1
             i += 1
             j += 1
             continue
 
-        j_match = find_internal_match(ext_rec, internal, j, lookahead, ts_tol, float_tol)
-        i_match = find_external_match(int_rec, external, i, lookahead, ts_tol, float_tol)
+        j_match = find_internal_match(
+            ext_rec, internal, j, lookahead, ts_tol, float_tol, int_rel_tol
+        )
+        i_match = find_external_match(
+            int_rec, external, i, lookahead, ts_tol, float_tol, int_rel_tol
+        )
 
         if j_match is not None and (i_match is None or (j_match - j) <= (i_match - i)):
             for missing_j in range(j, j_match):
@@ -293,7 +313,7 @@ def compare_peer(external, internal, ts_tol, float_tol, lookahead):
             discrepancies.append({
                 "kind": "field_mismatch",
                 "ts_delta": ts_delta,
-                "field_diffs": field_diffs(ext_rec, int_rec, float_tol),
+                "field_diffs": field_diffs(ext_rec, int_rec, float_tol, int_rel_tol),
                 "external": ext_rec["raw"],
                 "internal": int_rec["raw"],
             })
@@ -328,9 +348,83 @@ def compare_peer(external, internal, ts_tol, float_tol, lookahead):
     return matched, discrepancies
 
 
-def print_discrepancy(nodeid, index, discrepancy):
+def fmt_ts(ts):
+    if ts is None:
+        return "n/a"
+    return f"{float(ts):.6f}"
+
+
+def fmt_ts_local(ts):
+    if ts is None:
+        return "n/a"
+    ts_f = float(ts)
+    local_dt = datetime.fromtimestamp(ts_f).astimezone()
+    return f"{ts_f:.6f} ({local_dt.strftime('%Y-%m-%d %H:%M:%S.%f %z')})"
+
+
+def neighbor_summary(target_ts, candidates):
+    if target_ts is None:
+        return {
+            "prev": None,
+            "next": None,
+            "nearest": None,
+            "nearest_delta": None,
+        }
+    if not candidates:
+        return {
+            "prev": None,
+            "next": None,
+            "nearest": None,
+            "nearest_delta": None,
+        }
+    idx = bisect.bisect_left(candidates, target_ts)
+    prev_ts = candidates[idx - 1] if idx > 0 else None
+    next_ts = candidates[idx] if idx < len(candidates) else None
+    nearest = prev_ts
+    if nearest is None or (
+        next_ts is not None and abs(next_ts - target_ts) < abs(nearest - target_ts)
+    ):
+        nearest = next_ts
+    nearest_delta = None if nearest is None else (target_ts - nearest)
+    return {
+        "prev": prev_ts,
+        "next": next_ts,
+        "nearest": nearest,
+        "nearest_delta": nearest_delta,
+    }
+
+
+def print_discrepancy(nodeid, index, discrepancy, external_ts, internal_ts):
     kind = discrepancy["kind"]
     print(f"  discrepancy {index} ({kind}) for {nodeid}")
+
+    if kind == "missing_internal":
+        ext_ts = float(discrepancy["external"]["ts"])
+        summary = neighbor_summary(ext_ts, internal_ts)
+        print(
+            "    external_ts={ext} internal_prev_ts={prev} internal_next_ts={nxt} "
+            "nearest_internal_delta={delta}".format(
+                ext=fmt_ts_local(ext_ts),
+                prev=fmt_ts_local(summary["prev"]),
+                nxt=fmt_ts_local(summary["next"]),
+                delta=fmt_ts(summary["nearest_delta"]),
+            )
+        )
+        return
+    if kind == "extra_internal":
+        int_ts = float(discrepancy["internal"]["ts"])
+        summary = neighbor_summary(int_ts, external_ts)
+        print(
+            "    internal_ts={it} external_prev_ts={prev} external_next_ts={nxt} "
+            "nearest_external_delta={delta}".format(
+                it=fmt_ts_local(int_ts),
+                prev=fmt_ts_local(summary["prev"]),
+                nxt=fmt_ts_local(summary["next"]),
+                delta=fmt_ts(summary["nearest_delta"]),
+            )
+        )
+        return
+
     if "ts_delta" in discrepancy:
         print(f"    ts_delta={discrepancy['ts_delta']:.6f}")
     if "field_diffs" in discrepancy:
@@ -365,19 +459,23 @@ def main():
         required=True,
         help=(
             "Start time (Unix epoch seconds, ISO-8601, HH:MM[:SS], "
-            "YYYY-MM, YYYY-MM-DD, or relative +/-Nd)."
+            "YYYY-MM, YYYY-MM-DD, or relative +/-Nd). Naive/non-offset "
+            "timestamps are interpreted in local time."
         ),
     )
     parser.add_argument(
         "--before",
         default=None,
-        help="Optional end time (same formats as --since).",
+        help=(
+            "Optional end time (same formats as --since). "
+            "Naive/non-offset timestamps are interpreted in local time."
+        ),
     )
     parser.add_argument(
         "--ts-tolerance",
         type=float,
-        default=3.0,
-        help="Allowed timestamp delta in seconds (default: 3).",
+        default=20.0,
+        help="Allowed timestamp delta in seconds (default: 20).",
     )
     parser.add_argument(
         "--float-tolerance",
@@ -385,6 +483,16 @@ def main():
         default=1e-5,
         help=(
             "Float tolerance for comparison (default: 1e-5). "
+            "Effective limit is tolerance*max(1, |a|, |b|)."
+        ),
+    )
+    parser.add_argument(
+        "--int-rel-tolerance",
+        type=float,
+        default=1e-3,
+        help=(
+            "Relative tolerance for integer derived fields "
+            "(est_base/est_ppm), default: 1e-3. "
             "Effective limit is tolerance*max(1, |a|, |b|)."
         ),
     )
@@ -407,6 +515,8 @@ def main():
         raise SystemExit("Error: --ts-tolerance must be non-negative.")
     if args.float_tolerance < 0:
         raise SystemExit("Error: --float-tolerance must be non-negative.")
+    if args.int_rel_tolerance < 0:
+        raise SystemExit("Error: --int-rel-tolerance must be non-negative.")
     if args.lookahead < 0:
         raise SystemExit("Error: --lookahead must be non-negative.")
 
@@ -461,7 +571,12 @@ def main():
 
         total_internal += len(internal)
         matched, discrepancies = compare_peer(
-            external, internal, args.ts_tolerance, args.float_tolerance, args.lookahead
+            external,
+            internal,
+            args.ts_tolerance,
+            args.float_tolerance,
+            args.int_rel_tolerance,
+            args.lookahead,
         )
         total_matched += matched
         total_discrepancies += len(discrepancies)
@@ -473,8 +588,10 @@ def main():
             f"external={len(external)} internal={len(internal)} "
             f"matched={matched} discrepancies={len(discrepancies)}"
         )
+        external_ts = [record["ts"] for record in external]
+        internal_ts = [record["ts"] for record in internal]
         for d_idx, discrepancy in enumerate(discrepancies, start=1):
-            print_discrepancy(nodeid, d_idx, discrepancy)
+            print_discrepancy(nodeid, d_idx, discrepancy, external_ts, internal_ts)
 
     print("Summary:")
     print(f"  peers={len(peers)}")

--- a/contrib/feemon-validate
+++ b/contrib/feemon-validate
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+
+COMMON_FIELDS = [
+    "set_base",
+    "set_ppm",
+    "baseline_base",
+    "baseline_ppm",
+    "size_mult",
+    "size_total_peers",
+    "size_less_peers",
+    "balance_mult",
+    "balance_our_msat",
+    "balance_total_msat",
+    "price_level",
+    "price_mult",
+    "mult_product",
+    "est_base",
+    "est_ppm",
+]
+FLOAT_FIELDS = {
+    "size_mult",
+    "balance_mult",
+    "price_mult",
+    "mult_product",
+}
+
+
+def normalize_dt(dt):
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def parse_time_arg(value):
+    if value is None:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    if re.match(r"^[+-]?\d+(?:\.\d+)?$", value):
+        return datetime.fromtimestamp(float(value), timezone.utc)
+    if re.match(r"^[0-9]{4}-[0-9]{2}$", value):
+        return normalize_dt(datetime.fromisoformat(f"{value}-01T00:00:00"))
+    if re.match(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$", value):
+        return normalize_dt(datetime.fromisoformat(f"{value}T00:00:00"))
+    rel = re.match(r"^([+-]?)(\d+)([smhdw])$", value)
+    if rel:
+        sign, num_s, unit = rel.groups()
+        num = int(num_s)
+        delta = {
+            "s": timedelta(seconds=num),
+            "m": timedelta(minutes=num),
+            "h": timedelta(hours=num),
+            "d": timedelta(days=num),
+            "w": timedelta(weeks=num),
+        }[unit]
+        if sign == "-":
+            delta = -delta
+        return normalize_dt(datetime.now(timezone.utc) + delta)
+    if value.count(":") in (1, 2) and "T" not in value and "-" not in value:
+        today = datetime.now(timezone.utc).date().isoformat()
+        return normalize_dt(datetime.fromisoformat(f"{today}T{value}"))
+    return normalize_dt(datetime.fromisoformat(value))
+
+
+def epoch_arg(value):
+    text = f"{value:.6f}"
+    text = text.rstrip("0").rstrip(".")
+    if text == "":
+        return "0"
+    return text
+
+
+def add_lightning_args(parser):
+    parser.add_argument("--mainnet", action="store_true", help="Run on mainnet.")
+    parser.add_argument("--testnet", action="store_true", help="Run on testnet.")
+    parser.add_argument("--signet", action="store_true", help="Run on signet.")
+    parser.add_argument("--regtest", action="store_true", help="Run on regtest.")
+    parser.add_argument("--network", help="Set network explicitly.")
+    parser.add_argument("--lightning-dir", help="Path to lightning data directory.")
+
+
+def resolve_network_option(args):
+    if args.network:
+        return f"--network={args.network}"
+    if args.testnet:
+        return "--network=testnet"
+    if args.signet:
+        return "--network=signet"
+    if args.regtest:
+        return "--network=regtest"
+    return "--network=bitcoin"
+
+
+def resolve_lightning_dir(args):
+    if args.lightning_dir:
+        if not os.path.isdir(args.lightning_dir):
+            raise ValueError(f'"{args.lightning_dir}" is not a valid directory')
+        return args.lightning_dir
+    return None
+
+
+def run_lightning_cli_command(lightning_dir, network_option, subcommand, *args):
+    command = ["lightning-cli", network_option]
+    if lightning_dir:
+        command.append(f"--lightning-dir={lightning_dir}")
+    command.append(subcommand)
+    command.extend(args)
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        raise RuntimeError("lightning-cli not found in PATH")
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip()
+        if stderr:
+            raise RuntimeError(f"command failed: {' '.join(command)}: {stderr}")
+        raise RuntimeError(f"command failed: {' '.join(command)}")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"invalid JSON from lightning-cli: {e}")
+
+
+def fetch_external(conn, since_ts, before_ts):
+    conn.row_factory = sqlite3.Row
+    where = ["e.ts >= :since"]
+    binds = {"since": since_ts}
+    if before_ts is not None:
+        where.append("e.ts <= :before")
+        binds["before"] = before_ts
+    query = f"""
+        SELECT
+            p.node_id AS nodeid,
+            e.id,
+            e.ts,
+            e.peer_id,
+            e.set_base,
+            e.set_ppm,
+            e.baseline_base,
+            e.baseline_ppm,
+            e.size_mult,
+            e.size_total_peers,
+            e.size_less_peers,
+            e.balance_mult,
+            e.balance_our_msat,
+            e.balance_total_msat,
+            e.price_level,
+            e.price_mult,
+            e.mult_product,
+            e.est_base,
+            e.est_ppm,
+            e.dedupe_hash
+        FROM fee_change_events e
+        JOIN peers p ON p.id = e.peer_id
+        WHERE {" AND ".join(where)}
+        ORDER BY p.node_id ASC, e.ts ASC, e.id ASC
+    """
+    out = {}
+    for row in conn.execute(query, binds):
+        raw = dict(row)
+        nodeid = raw["nodeid"]
+        out.setdefault(nodeid, []).append(make_norm_record(raw))
+    return out
+
+
+def fetch_internal(lightning_dir, network_option, nodeid, since_ts, before_ts):
+    args = [nodeid, epoch_arg(since_ts)]
+    if before_ts is not None:
+        args.append(epoch_arg(before_ts))
+    rsp = run_lightning_cli_command(
+        lightning_dir, network_option, "clboss-feemon-history", *args
+    )
+    history = rsp.get("history")
+    if not isinstance(history, list):
+        raise RuntimeError("unexpected clboss-feemon-history response (no history)")
+    out = []
+    for item in history:
+        if not isinstance(item, dict):
+            continue
+        out.append(make_norm_record(item))
+    return out
+
+
+def make_norm_record(raw):
+    if "ts" not in raw:
+        raise RuntimeError(f"record missing ts: {raw}")
+    norm = {"ts": float(raw["ts"]), "fields": {}, "raw": raw}
+    for field in COMMON_FIELDS:
+        value = raw.get(field)
+        if value is None:
+            norm["fields"][field] = None
+        elif field in FLOAT_FIELDS:
+            norm["fields"][field] = float(value)
+        else:
+            norm["fields"][field] = int(value)
+    return norm
+
+
+def field_equal(name, a, b, float_tol):
+    if a is None or b is None:
+        return a is None and b is None
+    if name in FLOAT_FIELDS:
+        # Handle JSON precision reduction robustly across different magnitudes.
+        # For values near zero this is absolute tolerance, otherwise relative.
+        scale = max(1.0, abs(float(a)), abs(float(b)))
+        return abs(float(a) - float(b)) <= (float_tol * scale)
+    return int(a) == int(b)
+
+
+def fields_equal(ext_rec, int_rec, float_tol):
+    for name in COMMON_FIELDS:
+        if not field_equal(name, ext_rec["fields"][name], int_rec["fields"][name], float_tol):
+            return False
+    return True
+
+
+def record_match(ext_rec, int_rec, ts_tol, float_tol):
+    if abs(ext_rec["ts"] - int_rec["ts"]) > ts_tol:
+        return False
+    return fields_equal(ext_rec, int_rec, float_tol)
+
+
+def find_internal_match(ext_rec, internal, start, lookahead, ts_tol, float_tol):
+    end = min(len(internal), start + lookahead + 1)
+    for j in range(start + 1, end):
+        if record_match(ext_rec, internal[j], ts_tol, float_tol):
+            return j
+    return None
+
+
+def find_external_match(int_rec, external, start, lookahead, ts_tol, float_tol):
+    end = min(len(external), start + lookahead + 1)
+    for i in range(start + 1, end):
+        if record_match(external[i], int_rec, ts_tol, float_tol):
+            return i
+    return None
+
+
+def field_diffs(ext_rec, int_rec, float_tol):
+    diffs = []
+    for name in COMMON_FIELDS:
+        a = ext_rec["fields"][name]
+        b = int_rec["fields"][name]
+        if not field_equal(name, a, b, float_tol):
+            diffs.append({"field": name, "external": a, "internal": b})
+    return diffs
+
+
+def compare_peer(external, internal, ts_tol, float_tol, lookahead):
+    matched = 0
+    discrepancies = []
+    i = 0
+    j = 0
+    while i < len(external) and j < len(internal):
+        ext_rec = external[i]
+        int_rec = internal[j]
+        if record_match(ext_rec, int_rec, ts_tol, float_tol):
+            matched += 1
+            i += 1
+            j += 1
+            continue
+
+        j_match = find_internal_match(ext_rec, internal, j, lookahead, ts_tol, float_tol)
+        i_match = find_external_match(int_rec, external, i, lookahead, ts_tol, float_tol)
+
+        if j_match is not None and (i_match is None or (j_match - j) <= (i_match - i)):
+            for missing_j in range(j, j_match):
+                discrepancies.append({
+                    "kind": "extra_internal",
+                    "internal": internal[missing_j]["raw"],
+                })
+            j = j_match
+            continue
+        if i_match is not None:
+            for missing_i in range(i, i_match):
+                discrepancies.append({
+                    "kind": "missing_internal",
+                    "external": external[missing_i]["raw"],
+                })
+            i = i_match
+            continue
+
+        ts_delta = ext_rec["ts"] - int_rec["ts"]
+        if abs(ts_delta) <= ts_tol:
+            discrepancies.append({
+                "kind": "field_mismatch",
+                "ts_delta": ts_delta,
+                "field_diffs": field_diffs(ext_rec, int_rec, float_tol),
+                "external": ext_rec["raw"],
+                "internal": int_rec["raw"],
+            })
+            i += 1
+            j += 1
+        elif ext_rec["ts"] < int_rec["ts"]:
+            discrepancies.append({
+                "kind": "missing_internal",
+                "external": ext_rec["raw"],
+            })
+            i += 1
+        else:
+            discrepancies.append({
+                "kind": "extra_internal",
+                "internal": int_rec["raw"],
+            })
+            j += 1
+
+    while i < len(external):
+        discrepancies.append({
+            "kind": "missing_internal",
+            "external": external[i]["raw"],
+        })
+        i += 1
+    while j < len(internal):
+        discrepancies.append({
+            "kind": "extra_internal",
+            "internal": internal[j]["raw"],
+        })
+        j += 1
+
+    return matched, discrepancies
+
+
+def print_discrepancy(nodeid, index, discrepancy):
+    kind = discrepancy["kind"]
+    print(f"  discrepancy {index} ({kind}) for {nodeid}")
+    if "ts_delta" in discrepancy:
+        print(f"    ts_delta={discrepancy['ts_delta']:.6f}")
+    if "field_diffs" in discrepancy:
+        for diff in discrepancy["field_diffs"]:
+            print(
+                "    field {field}: external={external} internal={internal}".format(
+                    field=diff["field"],
+                    external=diff["external"],
+                    internal=diff["internal"],
+                )
+            )
+    if "external" in discrepancy:
+        print("    external:", json.dumps(discrepancy["external"], sort_keys=True))
+    if "internal" in discrepancy:
+        print("    internal:", json.dumps(discrepancy["internal"], sort_keys=True))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate external fee-log-parser sqlite data against "
+            "clboss-feemon-history."
+        )
+    )
+    parser.add_argument(
+        "--db",
+        default=os.path.expanduser("./clboss-fee-info.sqlite3"),
+        help="Path to external sqlite database (default: ./clboss-fee-info.sqlite3).",
+    )
+    parser.add_argument(
+        "--since",
+        required=True,
+        help=(
+            "Start time (Unix epoch seconds, ISO-8601, HH:MM[:SS], "
+            "YYYY-MM, YYYY-MM-DD, or relative +/-Nd)."
+        ),
+    )
+    parser.add_argument(
+        "--before",
+        default=None,
+        help="Optional end time (same formats as --since).",
+    )
+    parser.add_argument(
+        "--ts-tolerance",
+        type=float,
+        default=3.0,
+        help="Allowed timestamp delta in seconds (default: 3).",
+    )
+    parser.add_argument(
+        "--float-tolerance",
+        type=float,
+        default=1e-5,
+        help=(
+            "Float tolerance for comparison (default: 1e-5). "
+            "Effective limit is tolerance*max(1, |a|, |b|)."
+        ),
+    )
+    parser.add_argument(
+        "--lookahead",
+        type=int,
+        default=3,
+        help="Lookahead window used to re-sync around missing/extra records (default: 3).",
+    )
+    add_lightning_args(parser)
+    args = parser.parse_args()
+
+    since_dt = parse_time_arg(args.since)
+    before_dt = parse_time_arg(args.before) if args.before is not None else None
+    since_ts = since_dt.timestamp()
+    before_ts = before_dt.timestamp() if before_dt is not None else None
+    if before_ts is not None and since_ts > before_ts:
+        raise SystemExit("Error: --since must be less than or equal to --before.")
+    if args.ts_tolerance < 0:
+        raise SystemExit("Error: --ts-tolerance must be non-negative.")
+    if args.float_tolerance < 0:
+        raise SystemExit("Error: --float-tolerance must be non-negative.")
+    if args.lookahead < 0:
+        raise SystemExit("Error: --lookahead must be non-negative.")
+
+    network_option = resolve_network_option(args)
+    try:
+        lightning_dir = resolve_lightning_dir(args)
+    except ValueError as e:
+        raise SystemExit(f"Error: {e}")
+
+    try:
+        conn = sqlite3.connect(args.db)
+    except sqlite3.Error as e:
+        raise SystemExit(f"Error opening sqlite DB {args.db}: {e}")
+
+    try:
+        external_by_peer = fetch_external(conn, since_ts, before_ts)
+    except sqlite3.Error as e:
+        raise SystemExit(f"Error reading external DB schema/data: {e}")
+    finally:
+        conn.close()
+
+    peers = sorted(external_by_peer.keys())
+    print(
+        f"Loaded external data for {len(peers)} peers "
+        f"from {args.db} in [{since_ts}, {before_ts if before_ts is not None else 'inf'}]."
+    )
+    if not peers:
+        print("No external records in the selected window.")
+        return 0
+
+    total_matched = 0
+    total_external = 0
+    total_internal = 0
+    total_discrepancies = 0
+    peers_with_discrepancies = 0
+
+    for index, nodeid in enumerate(peers, start=1):
+        external = external_by_peer[nodeid]
+        total_external += len(external)
+
+        try:
+            internal = fetch_internal(
+                lightning_dir,
+                network_option,
+                nodeid,
+                since_ts,
+                before_ts,
+            )
+        except RuntimeError as e:
+            print(f"[{index}/{len(peers)}] {nodeid}: RPC error: {e}", file=sys.stderr)
+            return 2
+
+        total_internal += len(internal)
+        matched, discrepancies = compare_peer(
+            external, internal, args.ts_tolerance, args.float_tolerance, args.lookahead
+        )
+        total_matched += matched
+        total_discrepancies += len(discrepancies)
+        if discrepancies:
+            peers_with_discrepancies += 1
+
+        print(
+            f"[{index}/{len(peers)}] {nodeid}: "
+            f"external={len(external)} internal={len(internal)} "
+            f"matched={matched} discrepancies={len(discrepancies)}"
+        )
+        for d_idx, discrepancy in enumerate(discrepancies, start=1):
+            print_discrepancy(nodeid, d_idx, discrepancy)
+
+    print("Summary:")
+    print(f"  peers={len(peers)}")
+    print(f"  peers_with_discrepancies={peers_with_discrepancies}")
+    print(f"  external_records={total_external}")
+    print(f"  internal_records={total_internal}")
+    print(f"  matched_records={total_matched}")
+    print(f"  discrepancies={total_discrepancies}")
+
+    if total_discrepancies > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/feemon-validate
+++ b/contrib/feemon-validate
@@ -474,8 +474,8 @@ def main():
     parser.add_argument(
         "--ts-tolerance",
         type=float,
-        default=20.0,
-        help="Allowed timestamp delta in seconds (default: 20).",
+        default=60.0,
+        help="Allowed timestamp delta in seconds (default: 60).",
     )
     parser.add_argument(
         "--float-tolerance",

--- a/contrib/feemon_data.py
+++ b/contrib/feemon_data.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+import json
+import shutil
+import sqlite3
+import subprocess
+
+
+COMMON_FIELDS = [
+    "set_base",
+    "set_ppm",
+    "baseline_base",
+    "baseline_ppm",
+    "size_mult",
+    "size_total_peers",
+    "size_less_peers",
+    "balance_mult",
+    "balance_our_msat",
+    "balance_total_msat",
+    "price_level",
+    "price_mult",
+    "mult_product",
+    "est_base",
+    "est_ppm",
+]
+FLOAT_FIELDS = {
+    "size_mult",
+    "balance_mult",
+    "price_mult",
+    "mult_product",
+}
+
+
+def epoch_arg(value):
+    text = f"{value:.6f}"
+    text = text.rstrip("0").rstrip(".")
+    if text == "":
+        return "0"
+    return text
+
+
+def _dt_to_epoch(dt):
+    if dt is None:
+        return None
+    return float(dt.timestamp())
+
+
+def _warn(warn, message):
+    if warn is not None:
+        warn(message)
+
+
+def run_lightning_cli_command(lightning_dir, network_option, subcommand, *args):
+    command = ["lightning-cli", network_option]
+    if lightning_dir:
+        command.append(f"--lightning-dir={lightning_dir}")
+    command.append(subcommand)
+    command.extend(args)
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        raise RuntimeError("lightning-cli not found in PATH")
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip()
+        if stderr:
+            raise RuntimeError(f"command failed: {' '.join(command)}: {stderr}")
+        raise RuntimeError(f"command failed: {' '.join(command)}")
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"invalid JSON from lightning-cli: {e}")
+
+
+def _normalize_field(name, value):
+    if value is None:
+        return None
+    try:
+        if name in FLOAT_FIELDS:
+            return float(value)
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_record(node_id, raw, source):
+    if "ts" not in raw:
+        return None
+    try:
+        ts = float(raw["ts"])
+    except (TypeError, ValueError):
+        return None
+
+    fields = {}
+    for field in COMMON_FIELDS:
+        fields[field] = _normalize_field(field, raw.get(field))
+
+    return {
+        "node_id": node_id,
+        "ts": ts,
+        "fields": fields,
+        "raw": raw,
+        "source": source,
+    }
+
+
+def _record_sort_key(record):
+    raw_id = record["raw"].get("id")
+    try:
+        raw_id = int(raw_id)
+    except (TypeError, ValueError):
+        raw_id = -1
+    source_rank = 0 if record["source"] == "external" else 1
+    return (record["ts"], source_rank, raw_id)
+
+
+def _fetch_api_peer_history(
+    node_id, since_ts, before_ts, lightning_dir, network_option, warn, api_enabled
+):
+    if not api_enabled:
+        return []
+
+    args = [node_id]
+    if since_ts is not None:
+        args.append(epoch_arg(since_ts))
+    if before_ts is not None:
+        args.append(epoch_arg(before_ts))
+
+    try:
+        response = run_lightning_cli_command(
+            lightning_dir, network_option, "clboss-feemon-history", *args
+        )
+    except RuntimeError:
+        _warn(
+            warn,
+            "unable to fetch API fee monitor data; using external DB fallback",
+        )
+        return []
+
+    history = response.get("history") if isinstance(response, dict) else None
+    if not isinstance(history, list):
+        _warn(
+            warn,
+            "unexpected clboss-feemon-history response; using external DB fallback",
+        )
+        return []
+
+    out = []
+    for item in history:
+        if not isinstance(item, dict):
+            continue
+        rec = _normalize_record(node_id, item, "api")
+        if rec is None:
+            continue
+        out.append(rec)
+
+    out.sort(key=_record_sort_key)
+    return out
+
+
+def _fetch_external_peer_history(
+    conn, node_id, since_ts, before_ts, before_inclusive=True
+):
+    where = ["p.node_id = :node_id"]
+    binds = {"node_id": node_id}
+    if since_ts is not None:
+        where.append("e.ts >= :since")
+        binds["since"] = since_ts
+    if before_ts is not None:
+        op = "<=" if before_inclusive else "<"
+        where.append(f"e.ts {op} :before")
+        binds["before"] = before_ts
+
+    query = f"""
+        SELECT
+            e.id,
+            e.ts,
+            e.set_base,
+            e.set_ppm,
+            e.baseline_base,
+            e.baseline_ppm,
+            e.size_mult,
+            e.size_total_peers,
+            e.size_less_peers,
+            e.balance_mult,
+            e.balance_our_msat,
+            e.balance_total_msat,
+            e.price_level,
+            e.price_mult,
+            e.mult_product,
+            e.est_base,
+            e.est_ppm
+        FROM fee_change_events e
+        JOIN peers p ON p.id = e.peer_id
+        WHERE {" AND ".join(where)}
+        ORDER BY e.ts ASC, e.id ASC
+    """
+    out = []
+    for row in conn.execute(query, binds):
+        rec = _normalize_record(node_id, dict(row), "external")
+        if rec is None:
+            continue
+        out.append(rec)
+    return out
+
+
+def list_external_node_ids(db_path, since_dt=None, before_dt=None):
+    since_ts = _dt_to_epoch(since_dt)
+    before_ts = _dt_to_epoch(before_dt)
+    where = []
+    binds = {}
+    if since_ts is not None:
+        where.append("e.ts >= :since")
+        binds["since"] = since_ts
+    if before_ts is not None:
+        where.append("e.ts <= :before")
+        binds["before"] = before_ts
+
+    query = [
+        "SELECT DISTINCT p.node_id",
+        "FROM fee_change_events e",
+        "JOIN peers p ON p.id = e.peer_id",
+    ]
+    if where:
+        query.append("WHERE " + " AND ".join(where))
+    query.append("ORDER BY p.node_id ASC")
+    sql = "\n".join(query)
+
+    with sqlite3.connect(db_path) as conn:
+        return [row[0] for row in conn.execute(sql, binds)]
+
+
+def list_api_node_ids(lightning_dir, network_option, warn=None):
+    if shutil.which("lightning-cli") is None:
+        _warn(warn, "lightning-cli not found; using external DB data only")
+        return []
+
+    try:
+        response = run_lightning_cli_command(
+            lightning_dir, network_option, "listpeerchannels"
+        )
+    except RuntimeError as e:
+        _warn(
+            warn,
+            f"unable to list peers from API ({e}); using external DB data only",
+        )
+        return []
+
+    channels = response.get("channels") if isinstance(response, dict) else None
+    if not isinstance(channels, list):
+        _warn(warn, "unexpected listpeerchannels response; using external DB data only")
+        return []
+
+    peers = set()
+    for ch in channels:
+        if not isinstance(ch, dict):
+            continue
+        peer_id = ch.get("peer_id")
+        if isinstance(peer_id, str) and peer_id:
+            peers.add(peer_id)
+    return sorted(peers)
+
+
+def _merged_peer_records_from_conn(
+    conn, node_id, since_ts, before_ts, lightning_dir, network_option, warn, api_enabled
+):
+    api_records = _fetch_api_peer_history(
+        node_id,
+        since_ts,
+        before_ts,
+        lightning_dir,
+        network_option,
+        warn,
+        api_enabled,
+    )
+
+    if api_records:
+        api_earliest_ts = api_records[0]["ts"]
+        db_before_ts = api_earliest_ts
+        if before_ts is not None:
+            db_before_ts = min(db_before_ts, before_ts)
+        external_records = _fetch_external_peer_history(
+            conn, node_id, since_ts, db_before_ts, before_inclusive=False
+        )
+    else:
+        external_records = _fetch_external_peer_history(
+            conn, node_id, since_ts, before_ts, before_inclusive=True
+        )
+
+    merged = external_records + api_records
+    merged.sort(key=_record_sort_key)
+    return merged
+
+
+def load_merged_peer_records(
+    db_path,
+    node_id,
+    since_dt=None,
+    before_dt=None,
+    lightning_dir=None,
+    network_option="--network=bitcoin",
+    warn=None,
+):
+    since_ts = _dt_to_epoch(since_dt)
+    before_ts = _dt_to_epoch(before_dt)
+    api_enabled = shutil.which("lightning-cli") is not None
+    if not api_enabled:
+        _warn(warn, "lightning-cli not found; using external DB data only")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        return _merged_peer_records_from_conn(
+            conn,
+            node_id,
+            since_ts,
+            before_ts,
+            lightning_dir,
+            network_option,
+            warn,
+            api_enabled,
+        )
+
+
+def load_merged_records_by_node(
+    db_path,
+    node_ids,
+    api_node_ids=None,
+    since_dt=None,
+    before_dt=None,
+    lightning_dir=None,
+    network_option="--network=bitcoin",
+    warn=None,
+):
+    since_ts = _dt_to_epoch(since_dt)
+    before_ts = _dt_to_epoch(before_dt)
+    api_enabled = shutil.which("lightning-cli") is not None
+    if not api_enabled:
+        _warn(warn, "lightning-cli not found; using external DB data only")
+
+    out = {}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        api_nodes = None
+        if api_node_ids is not None:
+            api_nodes = set(api_node_ids)
+        for node_id in sorted(set(node_ids)):
+            node_api_enabled = api_enabled
+            if api_nodes is not None and node_id not in api_nodes:
+                node_api_enabled = False
+            merged = _merged_peer_records_from_conn(
+                conn,
+                node_id,
+                since_ts,
+                before_ts,
+                lightning_dir,
+                network_option,
+                warn,
+                node_api_enabled,
+            )
+            if merged:
+                out[node_id] = merged
+    return out
+
+
+def records_to_rows(records, fields):
+    rows = []
+    for record in records:
+        row = [record["ts"]]
+        for field in fields:
+            if field == "node_id":
+                row.append(record["node_id"])
+                continue
+            row.append(record["fields"].get(field))
+        rows.append(tuple(row))
+    return rows

--- a/contrib/feemon_data.py
+++ b/contrib/feemon_data.py
@@ -17,6 +17,7 @@ COMMON_FIELDS = [
     "balance_our_msat",
     "balance_total_msat",
     "price_level",
+    "price_center",
     "price_mult",
     "mult_product",
     "est_base",

--- a/contrib/feemon_data.py
+++ b/contrib/feemon_data.py
@@ -233,10 +233,56 @@ def list_external_node_ids(db_path, since_dt=None, before_dt=None):
         return [row[0] for row in conn.execute(sql, binds)]
 
 
-def list_api_node_ids(lightning_dir, network_option, warn=None):
+def _extract_peer_ids_from_list(value):
+    if not isinstance(value, list):
+        return None
+    peers = set()
+    for item in value:
+        if isinstance(item, str) and item:
+            peers.add(item)
+    return sorted(peers)
+
+
+def list_api_node_ids(
+    lightning_dir, network_option, since_dt=None, before_dt=None, warn=None
+):
     if shutil.which("lightning-cli") is None:
         _warn(warn, "lightning-cli not found; using external DB data only")
         return []
+
+    since_ts = _dt_to_epoch(since_dt)
+    before_ts = _dt_to_epoch(before_dt)
+    args = []
+    if since_ts is not None:
+        args.append(epoch_arg(since_ts))
+    if before_ts is not None:
+        args.append(epoch_arg(before_ts))
+
+    try:
+        response = run_lightning_cli_command(
+            lightning_dir, network_option, "clboss-feemon-peers", *args
+        )
+    except RuntimeError as e:
+        _warn(
+            warn,
+            f"unable to list peers from clboss-feemon-peers ({e}); "
+            "falling back to listpeerchannels",
+        )
+        response = None
+
+    if isinstance(response, dict):
+        peers = _extract_peer_ids_from_list(response.get("peers"))
+        if peers is not None:
+            return peers
+        _warn(
+            warn,
+            "unexpected clboss-feemon-peers response; falling back to listpeerchannels",
+        )
+    elif response is not None:
+        _warn(
+            warn,
+            "unexpected clboss-feemon-peers response; falling back to listpeerchannels",
+        )
 
     try:
         response = run_lightning_cli_command(
@@ -253,7 +299,6 @@ def list_api_node_ids(lightning_dir, network_option, warn=None):
     if not isinstance(channels, list):
         _warn(warn, "unexpected listpeerchannels response; using external DB data only")
         return []
-
     peers = set()
     for ch in channels:
         if not isinstance(ch, dict):

--- a/contrib/plot-aggregate
+++ b/contrib/plot-aggregate
@@ -6,16 +6,22 @@ import math
 import os
 import re
 import shutil
-import sqlite3
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
+
+from feemon_data import (
+    list_api_node_ids,
+    list_external_node_ids,
+    load_merged_records_by_node,
+)
 
 BUCKET_SECONDS = 24 * 60 * 60
 EARNINGS_SYMLOG_LINTHRESH = 1.0
 EARNINGS_SYMLOG_LINSCALE = 0.3
 FEE_SYMLOG_LINTHRESH = 1.0
 FEE_SYMLOG_LINSCALE = 0.3
+WARNED_FEEMON_MESSAGES = set()
 
 
 def local_tz():
@@ -398,24 +404,55 @@ def write_csv(args, rows, suffix):
         writer.writerows(rows)
 
 
-def fetch_field_values(db, from_ts, to_ts, field):
-    query = (
-        f"SELECT f.ts, f.{field}, p.node_id "
-        "FROM fee_change_events f "
-        "JOIN peers p ON p.id = f.peer_id "
-        f"WHERE f.{field} IS NOT NULL"
-    )
-    params = []
-    if from_ts:
-        query += " AND f.ts >= ?"
-        params.append(from_ts.timestamp())
-    if to_ts:
-        query += " AND f.ts <= ?"
-        params.append(to_ts.timestamp())
-    query += " ORDER BY f.ts"
+def warn_feemon_data(message):
+    if message in WARNED_FEEMON_MESSAGES:
+        return
+    WARNED_FEEMON_MESSAGES.add(message)
+    print(f"warning: {message}", file=sys.stderr)
 
-    with sqlite3.connect(db) as conn:
-        return conn.execute(query, params).fetchall()
+
+def get_fee_records_by_node(args):
+    if hasattr(args, "_fee_records_by_node"):
+        return args._fee_records_by_node
+
+    external_nodes = list_external_node_ids(
+        args.db,
+        since_dt=args.from_ts,
+        before_dt=args.to_ts,
+    )
+    api_nodes = list_api_node_ids(
+        args.resolved_lightning_dir,
+        args.network_option,
+        warn=warn_feemon_data,
+    )
+    node_ids = sorted(set(external_nodes) | set(api_nodes))
+    if not node_ids:
+        args._fee_records_by_node = {}
+        return args._fee_records_by_node
+
+    args._fee_records_by_node = load_merged_records_by_node(
+        args.db,
+        node_ids,
+        api_node_ids=api_nodes,
+        since_dt=args.from_ts,
+        before_dt=args.to_ts,
+        lightning_dir=args.resolved_lightning_dir,
+        network_option=args.network_option,
+        warn=warn_feemon_data,
+    )
+    return args._fee_records_by_node
+
+
+def fetch_field_values(args, field):
+    rows = []
+    for node_id, records in get_fee_records_by_node(args).items():
+        for record in records:
+            value = record["fields"].get(field)
+            if value is None:
+                continue
+            rows.append((record["ts"], value, node_id))
+    rows.sort(key=lambda row: (row[0], row[2]))
+    return rows
 
 
 def bucket_latest_by_node(rows):
@@ -441,8 +478,8 @@ def compute_percentile_series(buckets, percentiles):
     return series
 
 
-def get_percentile_series(db, from_ts, to_ts, field):
-    rows = fetch_field_values(db, from_ts, to_ts, field)
+def get_percentile_series(args, field):
+    rows = fetch_field_values(args, field)
     buckets = bucket_latest_by_node(rows)
     percentiles = [0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0]
     labels = ["p00", "p10", "p25", "p50", "p75", "p90", "p100"]
@@ -470,8 +507,8 @@ def fetch_earnings_history(args):
         print("warning: lightning-cli not found; skipping earnings data", file=sys.stderr)
         return []
 
-    network_option = resolve_network_option(args)
-    lightning_dir = resolve_lightning_dir(args)
+    network_option = args.network_option
+    lightning_dir = args.resolved_lightning_dir
     data = run_lightning_cli_command(
         lightning_dir, network_option, "clboss-earnings-history", "all"
     )
@@ -572,9 +609,7 @@ def plot_price_level(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
-    series, percentiles, labels = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "price_level"
-    )
+    series, percentiles, labels = get_percentile_series(args, "price_level")
     if not series:
         raise SystemExit("no theory_level data in time range")
 
@@ -617,9 +652,7 @@ def plot_baseline_base(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
-    series, percentiles, labels = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "baseline_base"
-    )
+    series, percentiles, labels = get_percentile_series(args, "baseline_base")
     if not series:
         raise SystemExit("no baseline_base data in time range")
 
@@ -654,9 +687,7 @@ def plot_baseline_ppm(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
-    series, percentiles, labels = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "baseline_ppm"
-    )
+    series, percentiles, labels = get_percentile_series(args, "baseline_ppm")
     if not series:
         raise SystemExit("no baseline_ppm data in time range")
 
@@ -691,9 +722,7 @@ def plot_size_mult(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
-    series, percentiles, labels = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "size_mult"
-    )
+    series, percentiles, labels = get_percentile_series(args, "size_mult")
     if not series:
         raise SystemExit("no size_mult data in time range")
 
@@ -727,9 +756,7 @@ def plot_balance_mult(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
-    series, percentiles, labels = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "balance_mult"
-    )
+    series, percentiles, labels = get_percentile_series(args, "balance_mult")
     if not series:
         raise SystemExit("no balance_mult data in time range")
 
@@ -763,9 +790,7 @@ def plot_set_base(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
-    series, percentiles, labels = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "set_base"
-    )
+    series, percentiles, labels = get_percentile_series(args, "set_base")
     if not series:
         raise SystemExit("no advertised_base data in time range")
 
@@ -800,9 +825,7 @@ def plot_set_ppm(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
-    series, percentiles, labels = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "set_ppm"
-    )
+    series, percentiles, labels = get_percentile_series(args, "set_ppm")
     if not series:
         raise SystemExit("no advertised_ppm data in time range")
 
@@ -872,27 +895,13 @@ def plot_combo(args):
     except ImportError:
         raise SystemExit("matplotlib is required to output graphs.")
 
-    price_series, percentiles, labels = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "price_level"
-    )
-    base_series, _, _ = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "baseline_base"
-    )
-    ppm_series, _, _ = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "baseline_ppm"
-    )
-    size_series, _, _ = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "size_mult"
-    )
-    balance_series, _, _ = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "balance_mult"
-    )
-    set_base_series, _, _ = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "set_base"
-    )
-    set_ppm_series, _, _ = get_percentile_series(
-        args.db, args.from_ts, args.to_ts, "set_ppm"
-    )
+    price_series, percentiles, labels = get_percentile_series(args, "price_level")
+    base_series, _, _ = get_percentile_series(args, "baseline_base")
+    ppm_series, _, _ = get_percentile_series(args, "baseline_ppm")
+    size_series, _, _ = get_percentile_series(args, "size_mult")
+    balance_series, _, _ = get_percentile_series(args, "balance_mult")
+    set_base_series, _, _ = get_percentile_series(args, "set_base")
+    set_ppm_series, _, _ = get_percentile_series(args, "set_ppm")
     earnings_series, _, _ = get_earnings_percentile_series(args)
     if (
         not price_series
@@ -1075,7 +1084,7 @@ def plot_combo(args):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Plot aggregated fee statistics from clboss fee logs."
+        description="Plot aggregated fee statistics from merged API and legacy fee history."
     )
     parser.add_argument(
         "--view",
@@ -1097,6 +1106,8 @@ def main():
     add_lightning_args(parser)
 
     args = parser.parse_args()
+    args.network_option = resolve_network_option(args)
+    args.resolved_lightning_dir = resolve_lightning_dir(args)
     args.from_ts = parse_time_arg(args.from_ts)
     args.to_ts = parse_time_arg(args.to_ts)
 

--- a/contrib/plot-aggregate
+++ b/contrib/plot-aggregate
@@ -285,8 +285,8 @@ def percentile_from_sorted(values, q):
 def add_common_args(parser):
     parser.add_argument(
         "--db",
-        default=os.path.expanduser("./clboss-fee-info.sqlite3"),
-        help="Path to sqlite database.",
+        default=None,
+        help="Path to legacy sqlite database (optional; default: API only).",
     )
     parser.add_argument(
         "--png",
@@ -1110,6 +1110,11 @@ def main():
     args.resolved_lightning_dir = resolve_lightning_dir(args)
     args.from_ts = parse_time_arg(args.from_ts)
     args.to_ts = parse_time_arg(args.to_ts)
+
+    if args.db is None and shutil.which("lightning-cli") is None:
+        raise SystemExit(
+            "no data source available: provide --db or ensure lightning-cli is in PATH"
+        )
 
     if not args.png and not args.show and not args.csv:
         raise SystemExit("use --png to save, --show to display, or --csv to export")

--- a/contrib/plot-aggregate
+++ b/contrib/plot-aggregate
@@ -423,6 +423,8 @@ def get_fee_records_by_node(args):
     api_nodes = list_api_node_ids(
         args.resolved_lightning_dir,
         args.network_option,
+        since_dt=args.from_ts,
+        before_dt=args.to_ts,
         warn=warn_feemon_data,
     )
     node_ids = sorted(set(external_nodes) | set(api_nodes))

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -313,8 +313,8 @@ def set_symlog_ticks(ax, linthresh, symmetric=True):
 def add_common_args(parser):
     parser.add_argument(
         "--db",
-        default=os.path.expanduser("./clboss-fee-info.sqlite3"),
-        help="Path to sqlite database.",
+        default=None,
+        help="Path to legacy sqlite database (optional; default: API only).",
     )
     parser.add_argument(
         "--png",
@@ -1242,6 +1242,11 @@ def main():
     args.to_ts = parse_time_arg(args.to_ts)
     args.peer, args.peer_label = resolve_peer(args)
     args.title = args.peer_label if args.title is None else args.title
+
+    if args.db is None and shutil.which("lightning-cli") is None:
+        raise SystemExit(
+            "no data source available: provide --db or ensure lightning-cli is in PATH"
+        )
 
     if not args.png and not args.show and not args.csv:
         raise SystemExit("use --png to save, --show to display, or --csv to export")

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -563,7 +563,7 @@ CSV_FIELDS = [
     "price_level",
     "price_mult",
 ]
-PRICE_LEVEL_FIELDS = ["price_level", "price_mult"]
+PRICE_LEVEL_FIELDS = ["price_level", "price_mult", "price_center"]
 BASE_PPM_FIELDS = ["set_base", "set_ppm"]
 BASELINE_FIELDS = ["baseline_base", "baseline_ppm"]
 SIZE_MULT_FIELDS = ["size_total_peers", "size_less_peers", "size_mult"]
@@ -648,10 +648,17 @@ def plot_price_level_on(ax_level, rows, peer):
     rows = [r for r in rows if r[1] is not None]
     ts_levels = []
     levels = []
-    for t, level, _ in rows:
+    centers = []
+    has_center = False
+    for t, level, _, center in rows:
         ts = parse_ts(t)
         ts_levels.append(ts)
         levels.append(level)
+        if center is None:
+            centers.append(float("nan"))
+        else:
+            has_center = True
+            centers.append(float(center))
 
     if not ts_levels:
         raise SystemExit("no theory_level data for peer in time range")
@@ -663,6 +670,16 @@ def plot_price_level_on(ax_level, rows, peer):
         label="theory_level",
         color="orange",
     )
+    center_line = None
+    if has_center:
+        center_line, = ax_level.plot(
+            ts_levels,
+            centers,
+            linewidth=PLOT_LINEWIDTH,
+            label="theory_center",
+            color="red",
+            alpha=0.85,
+        )
 
     ax_level.set_ylabel("theory_level")
     ax_mult = ax_level.secondary_yaxis(
@@ -670,10 +687,19 @@ def plot_price_level_on(ax_level, rows, peer):
         functions=(price_level_to_mult, price_mult_to_level),
     )
     ax_mult.set_ylabel("theory_mult")
-    ax_level.legend([level_line], ["theory_level"])
+    if center_line is None:
+        ax_level.legend([level_line], ["theory_level"])
+    else:
+        ax_level.legend(
+            [level_line, center_line],
+            ["theory_level", "theory_center"],
+        )
     pad_top(ax_level)
-    mult_min = price_level_to_mult(min(levels))
-    mult_max = price_level_to_mult(max(levels))
+    scale_levels = levels
+    if has_center:
+        scale_levels = levels + [v for v in centers if not math.isnan(v)]
+    mult_min = price_level_to_mult(min(scale_levels))
+    mult_max = price_level_to_mult(max(scale_levels))
     mult_ticks = nice_mult_ticks(mult_min, mult_max)
     if mult_ticks:
         ax_mult.set_yticks(mult_ticks)

--- a/contrib/plot-fees
+++ b/contrib/plot-fees
@@ -5,13 +5,13 @@ import json
 import math
 import os
 import re
-import sqlite3
 import subprocess
 import shutil
 import sys
 from datetime import datetime, timedelta, timezone
 
 from clboss.alias_cache import is_nodeid, load_cache, lookup_alias, lookup_nodeid_by_alias
+from feemon_data import load_merged_peer_records, records_to_rows
 
 PLOT_LINEWIDTH = 1.5
 SCID_RE = re.compile(r"^\d+x\d+x\d+$")
@@ -422,8 +422,8 @@ def resolve_peer(args):
         return peer_input, peer_input
 
     cli_available = shutil.which("lightning-cli") is not None
-    network_option = resolve_network_option(args)
-    lightning_dir = resolve_lightning_dir(args)
+    network_option = args.network_option
+    lightning_dir = args.resolved_lightning_dir
 
     if is_scid(peer_input):
         if not cli_available:
@@ -483,8 +483,8 @@ def fetch_earnings_rows(args):
         print("warning: lightning-cli not found; skipping earnings plot", file=sys.stderr)
         return []
 
-    network_option = resolve_network_option(args)
-    lightning_dir = resolve_lightning_dir(args)
+    network_option = args.network_option
+    lightning_dir = args.resolved_lightning_dir
     data = run_lightning_cli_command(
         lightning_dir, network_option, "clboss-earnings-history", args.peer
     )
@@ -548,26 +548,56 @@ def write_csv(args, rows, suffix):
         writer.writerows(rows)
 
 
-CSV_QUERY = (
-    "SELECT f.ts, p.node_id, f.set_base, f.set_ppm, "
-    "f.baseline_base, f.baseline_ppm, f.size_mult, "
-    "f.size_total_peers, f.size_less_peers, f.balance_mult, "
-    "f.balance_our_msat, f.balance_total_msat, "
-    "f.price_level, f.price_mult "
-    "FROM fee_change_events f "
-    "JOIN peers p ON p.id = f.peer_id "
-    "WHERE p.node_id = ? ORDER BY f.ts"
-)
+CSV_FIELDS = [
+    "node_id",
+    "set_base",
+    "set_ppm",
+    "baseline_base",
+    "baseline_ppm",
+    "size_mult",
+    "size_total_peers",
+    "size_less_peers",
+    "balance_mult",
+    "balance_our_msat",
+    "balance_total_msat",
+    "price_level",
+    "price_mult",
+]
+PRICE_LEVEL_FIELDS = ["price_level", "price_mult"]
+BASE_PPM_FIELDS = ["set_base", "set_ppm"]
+BASELINE_FIELDS = ["baseline_base", "baseline_ppm"]
+SIZE_MULT_FIELDS = ["size_total_peers", "size_less_peers", "size_mult"]
+BALANCE_MULT_FIELDS = ["balance_our_msat", "balance_total_msat", "balance_mult"]
+WARNED_FEEMON_MESSAGES = set()
 
 
-def fetch_rows(db, query, peer):
-    with sqlite3.connect(db) as conn:
-        return conn.execute(query, (peer,)).fetchall()
+def warn_feemon_data(message):
+    if message in WARNED_FEEMON_MESSAGES:
+        return
+    WARNED_FEEMON_MESSAGES.add(message)
+    print(f"warning: {message}", file=sys.stderr)
+
+
+def get_fee_records(args):
+    if not hasattr(args, "_fee_records"):
+        args._fee_records = load_merged_peer_records(
+            args.db,
+            args.peer,
+            since_dt=args.from_ts,
+            before_dt=args.to_ts,
+            lightning_dir=args.resolved_lightning_dir,
+            network_option=args.network_option,
+            warn=warn_feemon_data,
+        )
+    return args._fee_records
+
+
+def fetch_rows(args, fields):
+    return records_to_rows(get_fee_records(args), fields)
 
 
 def fetch_csv_rows(args):
-    rows = fetch_rows(args.db, CSV_QUERY, args.peer)
-    return filter_by_time(rows, args.from_ts, args.to_ts)
+    return fetch_rows(args, CSV_FIELDS)
 
 
 def make_single_axes(plt):
@@ -582,7 +612,7 @@ def make_twin_axes(plt):
 
 
 def plot_single_view(
-    args, suffix, rows_query, axes_factory, plotter, use_plt_tight_layout=False
+    args, suffix, row_fields, axes_factory, plotter, use_plt_tight_layout=False
 ):
     try:
         import matplotlib.pyplot as plt
@@ -593,8 +623,7 @@ def plot_single_view(
 
         mpl.rcParams["timezone"] = "UTC"
 
-    rows = fetch_rows(args.db, rows_query, args.peer)
-    rows = filter_by_time(rows, args.from_ts, args.to_ts)
+    rows = fetch_rows(args, row_fields)
     csv_rows = fetch_csv_rows(args)
 
     fig, primary_ax, plot_axes = axes_factory(plt)
@@ -981,41 +1010,11 @@ def plot_earnings_single_on(ax, rows, direction):
     ax.legend(handles=[bars], labels=[f"earnings (sat/day) {label}"])
 
 
-PRICE_LEVEL_QUERY = (
-    "SELECT f.ts, f.price_level, f.price_mult "
-    "FROM fee_change_events f "
-    "JOIN peers p ON p.id = f.peer_id "
-    "WHERE p.node_id = ? ORDER BY f.ts"
-)
-BASE_PPM_QUERY = (
-    "SELECT f.ts, f.set_base, f.set_ppm FROM fee_change_events f "
-    "JOIN peers p ON p.id = f.peer_id "
-    "WHERE p.node_id = ? ORDER BY f.ts"
-)
-BASELINE_QUERY = (
-    "SELECT f.ts, f.baseline_base, f.baseline_ppm FROM fee_change_events f "
-    "JOIN peers p ON p.id = f.peer_id "
-    "WHERE p.node_id = ? ORDER BY f.ts"
-)
-SIZE_MULT_QUERY = (
-    "SELECT f.ts, f.size_total_peers, f.size_less_peers, f.size_mult "
-    "FROM fee_change_events f "
-    "JOIN peers p ON p.id = f.peer_id "
-    "WHERE p.node_id = ? ORDER BY f.ts"
-)
-BALANCE_MULT_QUERY = (
-    "SELECT f.ts, f.balance_our_msat, f.balance_total_msat, f.balance_mult "
-    "FROM fee_change_events f "
-    "JOIN peers p ON p.id = f.peer_id "
-    "WHERE p.node_id = ? ORDER BY f.ts"
-)
-
-
 def plot_price_level(args):
     plot_single_view(
         args,
         "theory",
-        PRICE_LEVEL_QUERY,
+        PRICE_LEVEL_FIELDS,
         make_single_axes,
         plot_price_level_on,
     )
@@ -1025,7 +1024,7 @@ def plot_base_ppm(args):
     plot_single_view(
         args,
         "baseppm",
-        BASE_PPM_QUERY,
+        BASE_PPM_FIELDS,
         make_twin_axes,
     plot_base_ppm_on,
     )
@@ -1036,7 +1035,7 @@ def plot_baseline(args):
     plot_single_view(
         args,
         "baseline",
-        BASELINE_QUERY,
+        BASELINE_FIELDS,
         make_twin_axes,
     plot_baseline_on,
     )
@@ -1047,7 +1046,7 @@ def plot_size_mult(args):
     plot_single_view(
         args,
         "size",
-        SIZE_MULT_QUERY,
+        SIZE_MULT_FIELDS,
         make_twin_axes,
         plot_size_mult_on,
         use_plt_tight_layout=True,
@@ -1058,7 +1057,7 @@ def plot_balance_mult(args):
     plot_single_view(
         args,
         "balance",
-        BALANCE_MULT_QUERY,
+        BALANCE_MULT_FIELDS,
         make_twin_axes,
         plot_balance_mult_on,
         use_plt_tight_layout=True,
@@ -1085,20 +1084,13 @@ def plot_combo(args):
             if end_pad:
                 acc.append(ts + end_pad)
 
-    size_rows = fetch_rows(args.db, SIZE_MULT_QUERY, args.peer)
-    baseline_rows = fetch_rows(args.db, BASELINE_QUERY, args.peer)
-    balance_rows = fetch_rows(args.db, BALANCE_MULT_QUERY, args.peer)
-    price_rows = fetch_rows(args.db, PRICE_LEVEL_QUERY, args.peer)
-    base_rows = fetch_rows(args.db, BASE_PPM_QUERY, args.peer)
-    csv_rows = fetch_rows(args.db, CSV_QUERY, args.peer)
+    size_rows = fetch_rows(args, SIZE_MULT_FIELDS)
+    baseline_rows = fetch_rows(args, BASELINE_FIELDS)
+    balance_rows = fetch_rows(args, BALANCE_MULT_FIELDS)
+    price_rows = fetch_rows(args, PRICE_LEVEL_FIELDS)
+    base_rows = fetch_rows(args, BASE_PPM_FIELDS)
+    csv_rows = fetch_rows(args, CSV_FIELDS)
     earnings_rows = fetch_earnings_rows(args)
-
-    size_rows = filter_by_time(size_rows, args.from_ts, args.to_ts)
-    baseline_rows = filter_by_time(baseline_rows, args.from_ts, args.to_ts)
-    balance_rows = filter_by_time(balance_rows, args.from_ts, args.to_ts)
-    price_rows = filter_by_time(price_rows, args.from_ts, args.to_ts)
-    base_rows = filter_by_time(base_rows, args.from_ts, args.to_ts)
-    csv_rows = filter_by_time(csv_rows, args.from_ts, args.to_ts)
     fig, axes = plt.subplots(7, 1, figsize=(12, 21), sharex=True)
     (
         ax_baseline,
@@ -1191,7 +1183,7 @@ def plot_earnings_outgoing(args):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Plot fee-related time series from clboss fee logs."
+        description="Plot fee-related time series from merged API and legacy fee history."
     )
     parser.add_argument(
         "--view",
@@ -1217,6 +1209,8 @@ def main():
     add_common_args(parser)
 
     args = parser.parse_args()
+    args.network_option = resolve_network_option(args)
+    args.resolved_lightning_dir = resolve_lightning_dir(args)
     args.peer_input = args.peer
     args.from_ts = parse_time_arg(args.from_ts)
     args.to_ts = parse_time_arg(args.to_ts)

--- a/docs/COROUTINE.md
+++ b/docs/COROUTINE.md
@@ -1,0 +1,69 @@
+# Coroutine Pitfalls
+
+## Temporary Lifetime Pitfall (GCC 11/12)
+
+This note is for developers working on CLBOSS.  It summarizes a
+coroutine-related pitfall we hit and the mitigation pattern we
+adopted.
+
+### Rule of Thumb
+Do **not** put aggregate temporaries directly inside a `co_await`
+expression. Preconstruct them as locals, then `co_await` using the
+local variable.
+
+### Compiler Issue
+- GCC PR 107288	https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107288
+
+### Why This Helps
+Named locals have unambiguous lifetime across suspend/resume points.
+This avoids the GCC bug pattern where the compiler incorrectly manages
+the temporary lifetime of the aggregate constructed inside the
+`co_await` expression.
+
+### Toolchain Observed
+- GCC 11.4.0 (Ubuntu 22.04), `-std=gnu++20`
+- ASAN: `-fsanitize=address`, `-O1 -g -fno-omit-frame-pointer`
+
+### Wrong -> Right (Patch Example)
+```diff
+--- a/Boss/Mod/ChannelFeeSetter.cpp
++++ b/Boss/Mod/ChannelFeeSetter.cpp
+@@
+-    co_await bus.raise(Msg::MonitorFeeSetChannel{
+-        node,
+-        base,
+-        proportional
+-    });
++    Msg::MonitorFeeSetChannel msg{node, base, proportional};
++    co_await bus.raise(std::move(msg));
+```
+
+## Lambda Capture Lifetime Pitfall (Compiler-Specific)
+
+This is a separate (but similar) coroutine pitfall reported by
+ZmnSCPxj.  Some compilers incorrectly handle coroutine lambdas and
+their capture lifetimes.
+
+### Rule of Thumb
+Avoid *anonymous coroutine lambdas* entirely. Prefer **named functions**
+(member functions are fine) when writing coroutines.
+
+### Symptoms / Failure Mode
+Some compilers appear to assume the lambda object itself outlives the
+coroutine. They then destroy the lambda object once the next `Ev::Io`
+completes, which causes *all captures* to die after the first
+`co_await`. That includes reference captures (`&foo`) and `this`, since
+the storage for those references is owned by the lambda object.
+
+### Safe Patterns
+- For `bus.subscribe`, do *not* write a coroutine lambda directly.
+  Call a named coroutine member function instead.
+- For `.then(...)` chains, do *not* pass coroutine lambdas. The whole
+  point of coroutines is to avoid the `then` pyramid anyway.
+- If a function wants an `Ev::Io` (e.g., `Boss::concurrent`) and you
+  need a longer coroutine body, implement a named coroutine and call it.
+
+### Extra Safety
+Even with named coroutine functions, copy everything you need from any
+message *before* the first `co_await` (this is already part of the
+coroutine contract we follow elsewhere).

--- a/tests/boss/test_feemodderbypricetheory.cpp
+++ b/tests/boss/test_feemodderbypricetheory.cpp
@@ -1,8 +1,12 @@
 #undef NDEBUG
 #include"Boss/Mod/FeeModderByPriceTheory.hpp"
+#include"Boss/Mod/FeeMonitor.hpp"
+#include"Boss/Msg/CommandRequest.hpp"
+#include"Boss/Msg/CommandResponse.hpp"
 #include"Boss/Msg/DbResource.hpp"
 #include"Boss/Msg/ForwardFee.hpp"
 #include"Boss/Msg/ListpeersAnalyzedResult.hpp"
+#include"Boss/Msg/MonitorFeeSetChannel.hpp"
 #include"Boss/Msg/ProvideChannelFeeModifier.hpp"
 #include"Boss/Msg/SolicitChannelFeeModifier.hpp"
 #include"Boss/random_engine.hpp"
@@ -10,6 +14,7 @@
 #include"Ev/foreach.hpp"
 #include"Ev/start.hpp"
 #include"Ev/yield.hpp"
+#include"Jsmn/Object.hpp"
 #include"Ln/NodeId.hpp"
 #include"S/Bus.hpp"
 #include"Sqlite3.hpp"
@@ -257,6 +262,7 @@ public:
 int main() {
 	auto bus = S::Bus();
 	auto module_under_test = Boss::Mod::FeeModderByPriceTheory(bus);
+	auto fee_monitor = Boss::Mod::FeeMonitor(bus);
 	auto tester = Tester(bus);
 
 	auto modder = std::function< Ev::Io<double>( Ln::NodeId
@@ -271,6 +277,15 @@ int main() {
 	});
 
 	auto db = Sqlite3::Db(":memory:");
+	auto req_id = std::uint64_t();
+	auto last_rsp = Boss::Msg::CommandResponse{};
+	auto rsp = false;
+	bus.subscribe<Boss::Msg::CommandResponse
+		     >([&](Boss::Msg::CommandResponse const& m) {
+		last_rsp = m;
+		rsp = true;
+		return Ev::yield();
+	});
 
 	auto code = Ev::lift().then([&]() {
 		return bus.raise(Boss::Msg::DbResource{
@@ -280,6 +295,27 @@ int main() {
 
 		return tester.run();
 	}).then([&]() {
+		return bus.raise(Boss::Msg::MonitorFeeSetChannel{
+			A, 1000, 10
+		});
+	}).then([&]() {
+		++req_id;
+		rsp = false;
+		return bus.raise(Boss::Msg::CommandRequest{
+			"clboss-feemon-history",
+			Jsmn::Object::parse_json(
+				"[\"020000000000000000000000000000000000000000000000000000000000000001\"]"
+			),
+			Ln::CommandId::left(req_id)
+		});
+	}).then([&]() {
+		assert(rsp);
+		assert(last_rsp.id == Ln::CommandId::left(req_id));
+		auto result = Jsmn::Object::parse_json(
+			last_rsp.response.output().c_str()
+		);
+		assert(result["history"].size() == 1);
+		assert(double(result["history"][0]["set_base"]) == 1000.0);
 
 		return Ev::lift(0);
 	});

--- a/tests/boss/test_feemodderbypricetheory.cpp
+++ b/tests/boss/test_feemodderbypricetheory.cpp
@@ -316,6 +316,8 @@ int main() {
 		);
 		assert(result["history"].size() == 1);
 		assert(double(result["history"][0]["set_base"]) == 1000.0);
+		assert(result["history"][0].has("price_center"));
+		assert(!result["history"][0]["price_center"].is_null());
 
 		return Ev::lift(0);
 	});

--- a/tests/boss/test_feemon_history.cpp
+++ b/tests/boss/test_feemon_history.cpp
@@ -1,0 +1,213 @@
+#undef NDEBUG
+
+#include"Boss/Mod/FeeMonitor.hpp"
+#include"Boss/Msg/CommandRequest.hpp"
+#include"Boss/Msg/CommandResponse.hpp"
+#include"Boss/Msg/DbResource.hpp"
+#include"Boss/Msg/MonitorFeeByBalance.hpp"
+#include"Boss/Msg/MonitorFeeBySize.hpp"
+#include"Boss/Msg/MonitorFeeByTheory.hpp"
+#include"Boss/Msg/MonitorFeeSetChannel.hpp"
+#include"Boss/Msg/PeerMedianChannelFee.hpp"
+#include"Ev/coroutine.hpp"
+#include"Ev/start.hpp"
+#include"Ev/yield.hpp"
+#include"Jsmn/Object.hpp"
+#include"Ln/NodeId.hpp"
+#include"S/Bus.hpp"
+#include"Sqlite3.hpp"
+
+#include<assert.h>
+#include<cstdint>
+#include<iomanip>
+#include<sstream>
+
+namespace {
+auto const A = Ln::NodeId(
+	"020000000000000000000000000000000000000000000000000000000000000001"
+);
+auto const B = Ln::NodeId(
+	"020000000000000000000000000000000000000000000000000000000000000002"
+);
+auto const C = Ln::NodeId(
+	"020000000000000000000000000000000000000000000000000000000000000003"
+);
+auto const far_past = std::int64_t(0);
+auto const far_future = std::int64_t(4102444800);
+
+std::string make_since_query(char const* nodeid, std::int64_t since) {
+	auto os = std::ostringstream();
+	os << std::setprecision(17)
+	   << "{\"nodeid\":\"" << nodeid << "\",\"since\":" << since << "}";
+	return os.str();
+}
+
+std::string make_before_query(char const* nodeid, std::int64_t before) {
+	auto os = std::ostringstream();
+	os << std::setprecision(17)
+	   << "{\"nodeid\":\"" << nodeid << "\",\"before\":" << before << "}";
+	return os.str();
+}
+}
+
+Ev::Io<int> run() {
+	auto bus = S::Bus();
+	auto mut = Boss::Mod::FeeMonitor(bus);
+	auto db = Sqlite3::Db(":memory:");
+
+	auto req_id = std::uint64_t();
+	auto last_rsp = Boss::Msg::CommandResponse{};
+	auto rsp = false;
+	bus.subscribe<Boss::Msg::CommandResponse
+		     >([&](Boss::Msg::CommandResponse const& m) {
+		last_rsp = m;
+		rsp = true;
+		return Ev::yield();
+	});
+
+	co_await bus.raise(Boss::Msg::DbResource{db});
+	co_await bus.raise(Boss::Msg::PeerMedianChannelFee{A, 10, 100});
+	co_await bus.raise(Boss::Msg::MonitorFeeBySize{A, 10, 3, 1.1});
+	co_await bus.raise(Boss::Msg::MonitorFeeByBalance{A, 1.2, 1000, 2000});
+	co_await bus.raise(Boss::Msg::MonitorFeeByTheory{A, 5, 1.3});
+	co_await bus.raise(Boss::Msg::MonitorFeeSetChannel{A, 1000, 10});
+	co_await bus.raise(Boss::Msg::MonitorFeeSetChannel{B, 3000, 30});
+
+	++req_id;
+	rsp = false;
+	co_await bus.raise(Boss::Msg::CommandRequest{
+			"clboss-feemon-history",
+			Jsmn::Object::parse_json(
+				"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000001\"}"
+			),
+			Ln::CommandId::left(req_id)
+		});
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	auto result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	auto history = result["history"];
+	assert(history.size() == 1);
+	assert(double(history[0]["set_base"]) == 1000.0);
+
+	++req_id;
+	rsp = false;
+	co_await bus.raise(Boss::Msg::CommandRequest{
+			"clboss-feemon-history",
+			Jsmn::Object::parse_json(
+				make_since_query(
+					"020000000000000000000000000000000000000000000000000000000000000001",
+					far_past
+				).c_str()
+			),
+			Ln::CommandId::left(req_id)
+		});
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["history"].size() == 1);
+	assert(double(result["history"][0]["set_base"]) == 1000.0);
+
+	++req_id;
+	rsp = false;
+	co_await bus.raise(Boss::Msg::CommandRequest{
+			"clboss-feemon-history",
+			Jsmn::Object::parse_json(
+				make_before_query(
+					"020000000000000000000000000000000000000000000000000000000000000001",
+					far_past
+				).c_str()
+			),
+			Ln::CommandId::left(req_id)
+		});
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["history"].size() == 0);
+
+	++req_id;
+	rsp = false;
+	co_await bus.raise(Boss::Msg::CommandRequest{
+			"clboss-feemon-history",
+			Jsmn::Object::parse_json(
+				make_since_query(
+					"020000000000000000000000000000000000000000000000000000000000000001",
+					far_future
+				).c_str()
+			),
+			Ln::CommandId::left(req_id)
+		});
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["history"].size() == 0);
+
+	++req_id;
+	rsp = false;
+	co_await bus.raise(Boss::Msg::CommandRequest{
+			"clboss-feemon-history",
+			Jsmn::Object::parse_json(
+				make_before_query(
+					"020000000000000000000000000000000000000000000000000000000000000001",
+					far_future
+				).c_str()
+			),
+			Ln::CommandId::left(req_id)
+		});
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["history"].size() == 1);
+	assert(double(result["history"][0]["set_base"]) == 1000.0);
+
+	++req_id;
+	rsp = false;
+	co_await bus.raise(Boss::Msg::CommandRequest{
+			"clboss-feemon-history",
+			Jsmn::Object::parse_json(
+				"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000002\"}"
+			),
+			Ln::CommandId::left(req_id)
+		});
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["history"].size() == 1);
+	assert(double(result["history"][0]["set_base"]) == 3000.0);
+
+	++req_id;
+	rsp = false;
+	co_await bus.raise(Boss::Msg::CommandRequest{
+			"clboss-feemon-history",
+			Jsmn::Object::parse_json(
+				"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000003\"}"
+			),
+			Ln::CommandId::left(req_id)
+		});
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["history"].size() == 0);
+
+	co_return 0;
+}
+
+int main() {
+	auto io = run();
+	auto ec = Ev::start(io);
+	assert(ec == 0);
+	return 0;
+}

--- a/tests/boss/test_feemon_history.cpp
+++ b/tests/boss/test_feemon_history.cpp
@@ -65,23 +65,31 @@ Ev::Io<int> run() {
 		return Ev::yield();
 	});
 
-	co_await bus.raise(Boss::Msg::DbResource{db});
-	co_await bus.raise(Boss::Msg::PeerMedianChannelFee{A, 10, 100});
-	co_await bus.raise(Boss::Msg::MonitorFeeBySize{A, 10, 3, 1.1});
-	co_await bus.raise(Boss::Msg::MonitorFeeByBalance{A, 1.2, 1000, 2000});
-	co_await bus.raise(Boss::Msg::MonitorFeeByTheory{A, 5, 1.3});
-	co_await bus.raise(Boss::Msg::MonitorFeeSetChannel{A, 1000, 10});
-	co_await bus.raise(Boss::Msg::MonitorFeeSetChannel{B, 3000, 30});
+	auto msg_db = Boss::Msg::DbResource{db};
+	co_await bus.raise(std::move(msg_db));
+	auto msg_peer_median = Boss::Msg::PeerMedianChannelFee{A, 10, 100};
+	co_await bus.raise(std::move(msg_peer_median));
+	auto msg_fee_size = Boss::Msg::MonitorFeeBySize{A, 10, 3, 1.1};
+	co_await bus.raise(std::move(msg_fee_size));
+	auto msg_fee_balance = Boss::Msg::MonitorFeeByBalance{A, 1.2, 1000, 2000};
+	co_await bus.raise(std::move(msg_fee_balance));
+	auto msg_fee_theory = Boss::Msg::MonitorFeeByTheory{A, 5, 1.3};
+	co_await bus.raise(std::move(msg_fee_theory));
+	auto msg_set_a = Boss::Msg::MonitorFeeSetChannel{A, 1000, 10};
+	co_await bus.raise(std::move(msg_set_a));
+	auto msg_set_b = Boss::Msg::MonitorFeeSetChannel{B, 3000, 30};
+	co_await bus.raise(std::move(msg_set_b));
 
 	++req_id;
 	rsp = false;
-	co_await bus.raise(Boss::Msg::CommandRequest{
-			"clboss-feemon-history",
-			Jsmn::Object::parse_json(
-				"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000001\"}"
-			),
-			Ln::CommandId::left(req_id)
-		});
+	auto req_initial = Boss::Msg::CommandRequest{
+		"clboss-feemon-history",
+		Jsmn::Object::parse_json(
+			"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000001\"}"
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_initial));
 	assert(rsp);
 	assert(last_rsp.id == Ln::CommandId::left(req_id));
 	auto result = Jsmn::Object::parse_json(
@@ -93,16 +101,17 @@ Ev::Io<int> run() {
 
 	++req_id;
 	rsp = false;
-	co_await bus.raise(Boss::Msg::CommandRequest{
-			"clboss-feemon-history",
-			Jsmn::Object::parse_json(
-				make_since_query(
-					"020000000000000000000000000000000000000000000000000000000000000001",
-					far_past
-				).c_str()
-			),
-			Ln::CommandId::left(req_id)
-		});
+	auto req_since_past = Boss::Msg::CommandRequest{
+		"clboss-feemon-history",
+		Jsmn::Object::parse_json(
+			make_since_query(
+				"020000000000000000000000000000000000000000000000000000000000000001",
+				far_past
+			).c_str()
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_since_past));
 	assert(rsp);
 	assert(last_rsp.id == Ln::CommandId::left(req_id));
 	result = Jsmn::Object::parse_json(
@@ -113,16 +122,17 @@ Ev::Io<int> run() {
 
 	++req_id;
 	rsp = false;
-	co_await bus.raise(Boss::Msg::CommandRequest{
-			"clboss-feemon-history",
-			Jsmn::Object::parse_json(
-				make_before_query(
-					"020000000000000000000000000000000000000000000000000000000000000001",
-					far_past
-				).c_str()
-			),
-			Ln::CommandId::left(req_id)
-		});
+	auto req_before_past = Boss::Msg::CommandRequest{
+		"clboss-feemon-history",
+		Jsmn::Object::parse_json(
+			make_before_query(
+				"020000000000000000000000000000000000000000000000000000000000000001",
+				far_past
+			).c_str()
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_before_past));
 	assert(rsp);
 	assert(last_rsp.id == Ln::CommandId::left(req_id));
 	result = Jsmn::Object::parse_json(
@@ -132,16 +142,17 @@ Ev::Io<int> run() {
 
 	++req_id;
 	rsp = false;
-	co_await bus.raise(Boss::Msg::CommandRequest{
-			"clboss-feemon-history",
-			Jsmn::Object::parse_json(
-				make_since_query(
-					"020000000000000000000000000000000000000000000000000000000000000001",
-					far_future
-				).c_str()
-			),
-			Ln::CommandId::left(req_id)
-		});
+	auto req_since_future = Boss::Msg::CommandRequest{
+		"clboss-feemon-history",
+		Jsmn::Object::parse_json(
+			make_since_query(
+				"020000000000000000000000000000000000000000000000000000000000000001",
+				far_future
+			).c_str()
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_since_future));
 	assert(rsp);
 	assert(last_rsp.id == Ln::CommandId::left(req_id));
 	result = Jsmn::Object::parse_json(
@@ -151,16 +162,17 @@ Ev::Io<int> run() {
 
 	++req_id;
 	rsp = false;
-	co_await bus.raise(Boss::Msg::CommandRequest{
-			"clboss-feemon-history",
-			Jsmn::Object::parse_json(
-				make_before_query(
-					"020000000000000000000000000000000000000000000000000000000000000001",
-					far_future
-				).c_str()
-			),
-			Ln::CommandId::left(req_id)
-		});
+	auto req_before_future = Boss::Msg::CommandRequest{
+		"clboss-feemon-history",
+		Jsmn::Object::parse_json(
+			make_before_query(
+				"020000000000000000000000000000000000000000000000000000000000000001",
+				far_future
+			).c_str()
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_before_future));
 	assert(rsp);
 	assert(last_rsp.id == Ln::CommandId::left(req_id));
 	result = Jsmn::Object::parse_json(
@@ -171,13 +183,14 @@ Ev::Io<int> run() {
 
 	++req_id;
 	rsp = false;
-	co_await bus.raise(Boss::Msg::CommandRequest{
-			"clboss-feemon-history",
-			Jsmn::Object::parse_json(
-				"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000002\"}"
-			),
-			Ln::CommandId::left(req_id)
-		});
+	auto req_node_b = Boss::Msg::CommandRequest{
+		"clboss-feemon-history",
+		Jsmn::Object::parse_json(
+			"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000002\"}"
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_node_b));
 	assert(rsp);
 	assert(last_rsp.id == Ln::CommandId::left(req_id));
 	result = Jsmn::Object::parse_json(
@@ -188,13 +201,14 @@ Ev::Io<int> run() {
 
 	++req_id;
 	rsp = false;
-	co_await bus.raise(Boss::Msg::CommandRequest{
-			"clboss-feemon-history",
-			Jsmn::Object::parse_json(
-				"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000003\"}"
-			),
-			Ln::CommandId::left(req_id)
-		});
+	auto req_node_c = Boss::Msg::CommandRequest{
+		"clboss-feemon-history",
+		Jsmn::Object::parse_json(
+			"{\"nodeid\":\"020000000000000000000000000000000000000000000000000000000000000003\"}"
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_node_c));
 	assert(rsp);
 	assert(last_rsp.id == Ln::CommandId::left(req_id));
 	result = Jsmn::Object::parse_json(

--- a/tests/boss/test_feemon_history.cpp
+++ b/tests/boss/test_feemon_history.cpp
@@ -73,7 +73,7 @@ Ev::Io<int> run() {
 	co_await bus.raise(std::move(msg_fee_size));
 	auto msg_fee_balance = Boss::Msg::MonitorFeeByBalance{A, 1.2, 1000, 2000};
 	co_await bus.raise(std::move(msg_fee_balance));
-	auto msg_fee_theory = Boss::Msg::MonitorFeeByTheory{A, 5, 1.3};
+	auto msg_fee_theory = Boss::Msg::MonitorFeeByTheory{A, 5, 1.3, 7};
 	co_await bus.raise(std::move(msg_fee_theory));
 	auto msg_set_a = Boss::Msg::MonitorFeeSetChannel{A, 1000, 10};
 	co_await bus.raise(std::move(msg_set_a));
@@ -98,6 +98,8 @@ Ev::Io<int> run() {
 	auto history = result["history"];
 	assert(history.size() == 1);
 	assert(double(history[0]["set_base"]) == 1000.0);
+	assert(history[0].has("price_center"));
+	assert(double(history[0]["price_center"]) == 7.0);
 
 	++req_id;
 	rsp = false;
@@ -198,6 +200,8 @@ Ev::Io<int> run() {
 	);
 	assert(result["history"].size() == 1);
 	assert(double(result["history"][0]["set_base"]) == 3000.0);
+	assert(result["history"][0].has("price_center"));
+	assert(result["history"][0]["price_center"].is_null());
 
 	++req_id;
 	rsp = false;

--- a/tests/boss/test_feemon_history.cpp
+++ b/tests/boss/test_feemon_history.cpp
@@ -48,6 +48,20 @@ std::string make_before_query(char const* nodeid, std::int64_t before) {
 	   << "{\"nodeid\":\"" << nodeid << "\",\"before\":" << before << "}";
 	return os.str();
 }
+
+std::string make_since_window_query(std::int64_t since) {
+	auto os = std::ostringstream();
+	os << std::setprecision(17)
+	   << "{\"since\":" << since << "}";
+	return os.str();
+}
+
+std::string make_before_window_query(std::int64_t before) {
+	auto os = std::ostringstream();
+	os << std::setprecision(17)
+	   << "{\"before\":" << before << "}";
+	return os.str();
+}
 }
 
 Ev::Io<int> run() {
@@ -82,6 +96,76 @@ Ev::Io<int> run() {
 
 	++req_id;
 	rsp = false;
+	auto req_peers_initial = Boss::Msg::CommandRequest{
+		"clboss-feemon-peers",
+		Jsmn::Object::parse_json("{}"),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_peers_initial));
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	auto result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["peers"].size() == 2);
+	assert(std::string(result["peers"][0]) == std::string(A));
+	assert(std::string(result["peers"][1]) == std::string(B));
+
+	++req_id;
+	rsp = false;
+	auto req_peers_before_past = Boss::Msg::CommandRequest{
+		"clboss-feemon-peers",
+		Jsmn::Object::parse_json(
+			make_before_window_query(far_past).c_str()
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_peers_before_past));
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["peers"].size() == 0);
+
+	++req_id;
+	rsp = false;
+	auto req_peers_since_future = Boss::Msg::CommandRequest{
+		"clboss-feemon-peers",
+		Jsmn::Object::parse_json(
+			make_since_window_query(far_future).c_str()
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_peers_since_future));
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["peers"].size() == 0);
+
+	++req_id;
+	rsp = false;
+	auto req_peers_before_future = Boss::Msg::CommandRequest{
+		"clboss-feemon-peers",
+		Jsmn::Object::parse_json(
+			make_before_window_query(far_future).c_str()
+		),
+		Ln::CommandId::left(req_id)
+	};
+	co_await bus.raise(std::move(req_peers_before_future));
+	assert(rsp);
+	assert(last_rsp.id == Ln::CommandId::left(req_id));
+	result = Jsmn::Object::parse_json(
+		last_rsp.response.output().c_str()
+	);
+	assert(result["peers"].size() == 2);
+	assert(std::string(result["peers"][0]) == std::string(A));
+	assert(std::string(result["peers"][1]) == std::string(B));
+
+	++req_id;
+	rsp = false;
 	auto req_initial = Boss::Msg::CommandRequest{
 		"clboss-feemon-history",
 		Jsmn::Object::parse_json(
@@ -92,7 +176,7 @@ Ev::Io<int> run() {
 	co_await bus.raise(std::move(req_initial));
 	assert(rsp);
 	assert(last_rsp.id == Ln::CommandId::left(req_id));
-	auto result = Jsmn::Object::parse_json(
+	result = Jsmn::Object::parse_json(
 		last_rsp.response.output().c_str()
 	);
 	auto history = result["history"];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Adds FeeMonitor module for persistent fee tracking**: Introduces a new FeeMonitor class that subscribes to fee-related events and records per-channel fee statistics (base fees, proportional fees, and computed multipliers) to an SQLite database (feemon_peers and feemon_change_events tables). Provides a clboss-feemon-history CLI command to query historical fee changes with optional time-based filtering.

- **Integrates monitoring throughout fee-setting pipeline**: Updates four existing fee-modding modules (ChannelFeeSetter, FeeModderByBalance, FeeModderBySize, FeeModderByPriceTheory) to emit MonitorFee* messages when computing or setting fees, allowing FeeMonitor to capture baseline fees, size-based multipliers, balance-based multipliers, and price-theory-based multipliers for comprehensive per-peer tracking.

- **Adds validation tooling and comprehensive tests**: Includes a new feemon-validate Python utility to cross-validate fee records against external SQLite sources with configurable tolerances, plus new test cases covering history queries with various parameter combinations and verification of recorded fee data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->