### PR TITLE
Create v0.16.0 rc1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ config.h.in
 config.status
 config.h
 configure
-contrib/clboss/__pycache__/
+contrib/**/__pycache__/
 compile_commands.json
 *.log
 *.m4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,62 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [next rev]
+## [0.16.0] - 2026-03-02: "Darkness on the Edge of the Mempool"
+
+### Added
+
+- **Internal**:
+  - Fee Monitor module records per-channel fee-setting context and
+    statistics into SQLite (`feemon_peers`, `feemon_change_events`
+    tables). ([#296])
+  - C++20 coroutine support for cleaner async code. ([#272])
+- **RPC**:
+  - `clboss-feemon-history`: returns per-peer fee modifier history
+    (baseline, size/balance/price multipliers, earnings). ([#296])
+  - `clboss-feemon-peers`: returns peer node IDs with fee monitor data,
+    with optional time window filtering. ([#296])
+  - `clboss-earnings-history`: added "all" (by-node) aggregation mode.
+    ([#292])
+- **Contrib scripts**:
+  - `fee-log-parser`: parses DEBUG-level logs into SQLite. ([#291])
+  - `plot-fees`: plots per-peer fee time series. ([#291])
+  - `plot-aggregate`: plots aggregate percentile summaries across
+    peers. ([#291])
+  - `plot-balance-price`, `plot-size-balance`, `plot-size-price`: fee
+    modifier analysis visualizations. ([#295])
+  - `feemon-validate`: validates fee monitor data integrity. ([#296])
+- **Build**:
+  - `install-versioned` Makefile target for fast roll-forward/roll-back.
+    ([#289])
+  - Code coverage reporting in CI. ([#283])
+  - Nix flake packaging improvements. ([#285])
+
+### Changed
+
+- `InvoicePayer` now uses CLN's native `decode` RPC instead of manual
+  parsing. ([#301])
+
+### Fixed
+
+- `fundpsbt` deprecated integer argument handling. ([#288])
+- `Initiator` module handles both old and new `listconfigs` RPC output
+  formats. ([#300])
+- Backtrace capture disabled under valgrind to fix `make check`
+  failures. ([#279])
+- Fixed duplicate earnings report sections in README. ([#277])
+- Fixed outdated `setchannelfee` reference to `setchannel` in README.
+  ([#290])
+- Replaced deprecated `std::result_of` with `std::invoke_result_t` for
+  C++20 compatibility (fixes build on FreeBSD 14+ / clang 18). ([#305])
+
+### Credits
+
+Many thanks (!!) to contributors to this release:
+- @codepleb
+- @JosephGoulden
+- @smolting
+- @tank-welder
+- @ZmnSCPxj
 
 ## [0.15.1] - 2025-10-07: "Dancing in the Dark Liquidity"
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([clboss], [0.15.1], [ken@bonsai.com])
+AC_INIT([clboss], [0.16.0], [ken@bonsai.com])
 AC_CONFIG_AUX_DIR([auxdir])
 AM_INIT_AUTOMAKE([subdir-objects tar-ustar])
 AC_CONFIG_SRCDIR([main.cpp])


### PR DESCRIPTION
progress on #303 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Bumped version to 0.16.0 in configure.ac and updated CHANGELOG with release notes dated 2026-03-02 titled "Darkness on the Edge of the Mempool"
- Added features: C++20 coroutine support, SQLite-backed per-channel Fee Monitor persistence, three new RPCs (clboss-feemon-history, clboss-feemon-peers, clboss-earnings-history), and multiple contrib scripts for fee monitoring and visualization
- Fixes and housekeeping: corrected fundpsbt argument handling, Initiator RPC output formats, valgrind backtrace handling, README/reference fixes, and broadened .gitignore to recursively ignore contrib/**/__pycache__/
<!-- end of auto-generated comment: release notes by coderabbit.ai -->