### PR TITLE
Fix DNS seed parser crash on non-SRV records (#309)

### DIFF
--- a/Boss/Mod/ConnectFinderByDns.cpp
+++ b/Boss/Mod/ConnectFinderByDns.cpp
@@ -24,10 +24,14 @@ auto const all_dnsseeds =
 	std::map<Boss::Msg::Network, std::vector<std::pair< std::string
 							  , std::string
 							  >>>
-{ {Boss::Msg::Network_Bitcoin, { {"1.0.0.1", "lseed.bitcoinstats.com"}
-			       , {"8.8.8.8", "lseed.darosior.ninja"}
+{ {Boss::Msg::Network_Bitcoin, {
 			       }}
 };
+/* Both previous seeds are defunct as of 2026-03:
+ * - lseed.bitcoinstats.com — SERVFAIL
+ * - lseed.darosior.ninja — NXDOMAIN (confirmed by maintainer)
+ * See https://github.com/ksedgwic/clboss/issues/309
+ */
 /*
 <zmnscpxj> What other Lightning DNS seeds are there? lseed.darosior.ninja is not reliable from my connection, even with @1.1.1.1 or @8.8.8.8
 <zmnscpxj> lseed.bitcoinstats.com works with @1.1.1.1

--- a/DnsSeed/Detail/parse_dig_srv.cpp
+++ b/DnsSeed/Detail/parse_dig_srv.cpp
@@ -2,6 +2,7 @@
 #include"DnsSeed/Detail/parse_dig_srv.hpp"
 #include"Util/Str.hpp"
 #include<algorithm>
+#include<stdexcept>
 #include<sstream>
 
 namespace {
@@ -43,35 +44,50 @@ std::vector<Record> parse_dig_srv(std::string const& out) {
 		if (line[0] == ';')
 			continue;
 
-		auto fields = split_by_char(line, ' ');
+		/* Normalize tabs to spaces so field indices
+		 * are consistent across dig output formats.  */
+		auto normalized = line;
+		std::replace(normalized.begin(), normalized.end(), '\t', ' ');
+
+		auto fields = split_by_char(normalized, ' ');
 		fields.erase( std::remove( fields.begin(), fields.end()
 					 , ""
 					 )
 			    , fields.end()
 			    );
-		/* Skip abnormal lines.*/
-		if (fields.size() < 2)
+
+		/* SRV lines have at least 8 fields:
+		 * name TTL IN SRV priority weight port target.
+		 * Skip non-SRV records (e.g. SOA in AUTHORITY).  */
+		if (fields.size() < 8)
+			continue;
+		if (fields[3] != "SRV")
 			continue;
 
-		/* Extract port and host fields.  */
-		auto port_s = *(fields.end() - 2);
-		auto port = parse_port(port_s);
-		auto host = *(fields.end() - 1);
+		try {
+			/* Extract port and host fields.  */
+			auto port_s = *(fields.end() - 2);
+			auto port = parse_port(port_s);
+			auto host = *(fields.end() - 1);
 
-		/* Extract nodeid.  */
-		auto nodeid_s = std::string( host.begin()
-					   , std::find(host.begin(), host.end()
-						      , '.'
-						      )
-					   );
-		/* Parse it.  */
-		auto nodeid = decode_bech32_node(nodeid_s);
-		/* Print as hex.  */
-		auto nodeid_hex = Util::Str::hexdump( &nodeid[0]
-						    , nodeid.size()
-						    );
+			/* Extract nodeid.  */
+			auto nodeid_s = std::string(
+				  host.begin()
+				, std::find(host.begin(), host.end(), '.')
+			);
+			/* Parse it.  */
+			auto nodeid = decode_bech32_node(nodeid_s);
+			/* Print as hex.  */
+			auto nodeid_hex = Util::Str::hexdump(
+				  &nodeid[0]
+				, nodeid.size()
+			);
 
-		rv.push_back({nodeid_hex, port, host});
+			rv.push_back({nodeid_hex, port, host});
+		} catch (std::exception&) {
+			/* Skip records that fail to parse.  */
+			continue;
+		}
 	}
 
 	return rv;

--- a/DnsSeed/get.cpp
+++ b/DnsSeed/get.cpp
@@ -61,8 +61,6 @@ Ev::Io<std::vector<std::string>> get( std::string const& seed
 	/* Some ISPs have default resolvers which do not properly
 	 * handle SRV queries.
 	 * We thus require a resolver of some kind.
-	 * Generally this should be "1.0.0.1", but some DNS seeds
-	 * (darosior.ninja) need "8.8.8.8"
 	 */
 	auto at_resolver = std::string("@") + resolver;
 

--- a/tests/dnsseed/test_parse_dig_srv.cpp
+++ b/tests/dnsseed/test_parse_dig_srv.cpp
@@ -41,9 +41,71 @@ auto const reference = std::vector<DnsSeed::Detail::Record>
 , {"03f48fc5acea5b3878ff216027f367762805f02feab11a038ea2d144b0a3eb8a38", 9735, "ln1q06gl3dvafdns78ly9sz0um8wc5qtup0a2c35quw5tg5fv9raw9rstvrqk5.lseed.bitcoinstats.com."}
 };
 
+/* dig output for a defunct seed — NXDOMAIN with SOA in AUTHORITY.
+ * This is the exact crash trigger from issue #309.  */
+auto const text_soa =
+R"DIG(
+; <<>> DiG 9.18.28-1~deb12u2-Debian <<>> @8.8.8.8 lseed.darosior.ninja. SRV
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 12345
+;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 512
+;; QUESTION SECTION:
+;lseed.darosior.ninja.		IN	SRV
+
+;; AUTHORITY SECTION:
+ninja.	1800	IN	SOA	v0n0.nic.ninja. hostmaster.donuts.email. 1774274844 7200 900 1209600 3600
+
+;; Query time: 25 msec
+;; SERVER: 8.8.8.8#53(8.8.8.8)
+;; WHEN: Sun Mar 23 10:00:00 PDT 2026
+;; MSG SIZE  rcvd: 130
+
+)DIG"
+;
+
+/* dig output with SRV answers AND an SOA in the AUTHORITY section.  */
+auto const text_mixed =
+R"DIG(
+; <<>> DiG 9.18.28-1~deb12u2-Debian <<>> @1.0.0.1 lseed.bitcoinstats.com. SRV
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 54566
+;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 1
+
+;; OPT PSEUDOSECTION:
+; EDNS: version: 0, flags:; udp: 1232
+;; QUESTION SECTION:
+;lseed.bitcoinstats.com.		IN	SRV
+
+;; ANSWER SECTION:
+lseed.bitcoinstats.com.	52	IN	SRV	10 10 9735 ln1q03x4x8wf5fjp4tht74jj9vqj6gcqkfdkdneumfjudsdh528qek2xcr9vc3.lseed.bitcoinstats.com.
+lseed.bitcoinstats.com.	52	IN	SRV	10 10 9735 ln1qferzvzn7c7cn2whlrtq9x5h0dwm09hedryz6saeykpfrr7vfqj7wnfn3j2.lseed.bitcoinstats.com.
+
+;; AUTHORITY SECTION:
+bitcoinstats.com.	3600	IN	SOA	ns1.example.com. admin.example.com. 2021010100 3600 600 604800 3600
+
+;; Query time: 155 msec
+;; SERVER: 1.0.0.1#53(1.0.0.1)
+;; WHEN: Sun Mar 23 10:00:00 PDT 2026
+;; MSG SIZE  rcvd: 400
+
+)DIG"
+;
+
+auto const reference_mixed = std::vector<DnsSeed::Detail::Record>
+{ {"03e26a98ee4d1320d5775fab291580969180592db3679e6d32e360dbd147066ca3", 9735, "ln1q03x4x8wf5fjp4tht74jj9vqj6gcqkfdkdneumfjudsdh528qek2xcr9vc3.lseed.bitcoinstats.com."}
+, {"0272313053f63d89a9d7f8d6029a977b5db796f968c82d43b92582918fcc4825e7", 9735, "ln1qferzvzn7c7cn2whlrtq9x5h0dwm09hedryz6saeykpfrr7vfqj7wnfn3j2.lseed.bitcoinstats.com."}
+};
+
 }
 
-int main() {
+void test_srv_only() {
 	auto rv = DnsSeed::Detail::parse_dig_srv(text);
 	assert(rv.size() == reference.size());
 	for (auto i = size_t(0); i < rv.size(); ++i) {
@@ -51,5 +113,28 @@ int main() {
 		assert(rv[i].port == reference[i].port);
 		assert(rv[i].hostname == reference[i].hostname);
 	}
+}
+
+void test_soa_only() {
+	/* Issue #309: SOA records must not crash the parser.  */
+	auto rv = DnsSeed::Detail::parse_dig_srv(text_soa);
+	assert(rv.size() == 0);
+}
+
+void test_mixed_srv_and_soa() {
+	/* SRV records parsed, SOA records skipped.  */
+	auto rv = DnsSeed::Detail::parse_dig_srv(text_mixed);
+	assert(rv.size() == reference_mixed.size());
+	for (auto i = size_t(0); i < rv.size(); ++i) {
+		assert(rv[i].nodeid == reference_mixed[i].nodeid);
+		assert(rv[i].port == reference_mixed[i].port);
+		assert(rv[i].hostname == reference_mixed[i].hostname);
+	}
+}
+
+int main() {
+	test_srv_only();
+	test_soa_only();
+	test_mixed_srv_and_soa();
 	return 0;
 }


### PR DESCRIPTION
CLBOSS crashes with "Not a bech32 string: 3600" when a DNS seed query returns non-SRV records       (e.g. SOA in the AUTHORITY section). This happens reliably because lseed.darosior.ninja is defunct and returns NXDOMAIN with an SOA record.

- Filter parse_dig_srv() to only process SRV record lines, with try-catch as defense-in-depth
- Add unit tests reproducing the crash with SOA-only and mixed SRV/SOA dig output
- Remove both defunct seed entries (lseed.bitcoinstats.com SERVFAIL, lseed.darosior.ninja NXDOMAIN)                                                                                                                                                                                               

Tested on mainnet: confirmed crash without fix, confirmed clean startup with fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed DNS seed parser crash when queries return non-SRV records (e.g., SOA) by normalizing whitespace, filtering to only process lines with `fields[3] == "SRV"`, and wrapping record parsing in try-catch to skip malformed entries instead of failing entirely.
- Removed two defunct DNS seed entries (lseed.bitcoinstats.com returning SERVFAIL and lseed.darosior.ninja returning NXDOMAIN) that were triggering the crash, with graceful handling of empty seed lists via warning log.
- Added unit tests reproducing the original crash scenario with SOA-only and mixed SRV/SOA dig outputs to prevent regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->