### PR TITLE
cln-v26.06-compat: migrate getroute callers to getroutes

### DIFF
--- a/Boss/Mod/ActiveProber.cpp
+++ b/Boss/Mod/ActiveProber.cpp
@@ -215,11 +215,16 @@ private:
 		});
 	}
 
+	/* First hop after `peer`: the peer's neighbor that we probe
+	 * towards.  Extracted into typed values from getroutes' path[0]
+	 * so we can rebuild the sendpay hop later without keeping the
+	 * raw Jsmn::Object around.
+	 */
+	Ln::NodeId id1;
 	Ln::Scid chan1;
+	std::uint32_t direction1;
 	Ln::Amount amount1;
 	std::uint32_t delay1;
-	/* Route except for the 0th hop from us to peer.  */
-	Jsmn::Object route;
 
 	Ev::Io<void> getroute() {
 		if (to_try.empty())
@@ -233,38 +238,105 @@ private:
 
 			auto parms = Json::Out()
 				.start_object()
-					.field("fromid", std::string(peer))
-					.field("id", std::string(dest))
+					.field("source", std::string(peer))
+					.field("destination", std::string(dest))
 					.field("amount_msat", amount.to_msat())
-					/* I have written this many times,
-					 * but I never understood riskfactor.
+					/* No layers: source is a remote node
+					 * (peer), not us, so the
+					 * auto.localchans / auto.sourcefree
+					 * helpers do not apply -- they would
+					 * inject our private local channels
+					 * and zero out the source's outgoing
+					 * fees, either of which could make
+					 * askrene pick a path[0] that the
+					 * peer cannot actually reach via
+					 * public topology (and could even
+					 * produce a route that loops back
+					 * through us).
 					 */
-					.field("riskfactor", 10)
-					.field("fuzzpercent", 95)
-					.field("cltv", 14)
-					.start_array("exclude")
-						.entry(std::string(self_id))
-					.end_array()
+					.start_array("layers").end_array()
+					/* Generous max-fee tolerance for a
+					 * probe; askrene optimizes for
+					 * cheaper paths anyway via its
+					 * probability scoring.
+					 */
+					.field("maxfee_msat",
+					       (amount * 0.01).to_msat())
+					.field("final_cltv", 14)
+					.field("maxparts", 1)
 				.end_object()
 				;
-			return rpc.command("getroute", std::move(parms));
+			return rpc.command("getroutes", std::move(parms));
 		}).then([this](Jsmn::Object res) {
 			try {
-				route = res["route"];
-				auto hop1 = route[0];
-				chan1 = Ln::Scid(std::string(
-					hop1["channel"]
+				/* getroutes path[] hop fields were renamed
+				 * in CLN v26.06.  Which names actually get
+				 * emitted depends on the CLN version AND
+				 * whether the node runs with developer
+				 * mode (which suppresses deprecated
+				 * outputs):
+				 *
+				 *   v26.04                  -> old names only
+				 *   v26.06+ no developer    -> both names emitted
+				 *   v26.06+ developer=true  -> new names only
+				 *
+				 * Bridge by preferring the new name, falling
+				 * back to the old.  TODO: drop the fallback
+				 * once CLN v26.04 is no longer supported and
+				 * the old names are gone for good in v27.06.
+				 *
+				 * short_channel_id_dir is older (v24.11)
+				 * and is emitted unconditionally.
+				 */
+				auto path0 = res["routes"][0]["path"][0];
+				id1 = Ln::NodeId(std::string(
+					path0.has("node_id_out")
+						? path0["node_id_out"]
+						: path0["next_node_id"]
+				));
+				/* short_channel_id_dir is "SCID/dir"; split
+				 * into the SCID and the direction.  If
+				 * the slash is missing the response is
+				 * malformed; treat it as a parse error
+				 * so the enclosing handler logs and
+				 * skips this destination rather than
+				 * feeding garbage to Ln::Scid / std::stoul.
+				 */
+				auto sdir = std::string(
+					path0["short_channel_id_dir"]
+				);
+				auto slash = sdir.find('/');
+				if (slash == std::string::npos)
+					throw Jsmn::TypeError();
+				chan1 = Ln::Scid(sdir.substr(0, slash));
+				direction1 = std::uint32_t(std::stoul(
+					sdir.substr(slash + 1)
 				));
 				amount1 = Ln::Amount::object(
-					hop1["amount_msat"]
+					path0.has("amount_out_msat")
+						? path0["amount_out_msat"]
+						: path0["amount_msat"]
 				);
 				delay1 = std::uint32_t(double(
-					hop1["delay"]
+					path0.has("cltv_out")
+						? path0["cltv_out"]
+						: path0["delay"]
 				));
-			} catch (Jsmn::TypeError const& _) {
+			} catch (std::exception const& _) {
+				/* Broaden catch to std::exception so we also
+				 * handle std::invalid_argument and
+				 * std::out_of_range from std::stoul on a
+				 * malformed short_channel_id_dir tail.  Pop
+				 * the bad destination before logging so the
+				 * recursive getroute() picks a different
+				 * candidate instead of looping on the same
+				 * one indefinitely.
+				 */
+				if (!to_try.empty())
+					to_try.pop();
 				return Boss::log( bus, Error
 						, "ActiveProber: Unexpected "
-						  "result from getroute: %s"
+						  "result from getroutes: %s"
 						, Util::stringify(res).c_str()
 						).then([]() {
 					return Ev::lift(false);
@@ -379,11 +451,7 @@ private:
 	Ev::Io<void> sendpay() {
 		return Ev::lift().then([this]() {
 			auto os = std::ostringstream();
-			os << chan0;
-			for (auto step : route) {
-				os << " " << std::string(step["channel"]);
-				break;
-			}
+			os << chan0 << " " << std::string(chan1);
 			return Boss::log( bus, Debug
 					, "ActiveProber: Probe %s by route %s."
 					, std::string(peer).c_str()
@@ -405,28 +473,26 @@ private:
 					.field("delay", delay0)
 					.field("style", "tlv")
 				.end_object();
-			/* Load the rest of the path.  */
-			for (auto step : route) {
-				routearr.entry(step);
-				/* Break after the first hop on the route,
-				 * so that we always probe with a short
-				 * two-hop route (hop 0 above, and the
-				 * first hop of the `route`).
-				 *
-				 * This gives the peer the "benefit of
-				 * the doubt", meaning we only probe the
-				 * peer and *its* direct peer for uptime
-				 * and capacity.
-				 *
-				 * Nevertheless, this is still somewhat
-				 * "realistic" since we are probing for
-				 * routes that go towards popular nodes
-				 * (or at least to nodes that CLBOSS
-				 * thinks are good to have capacity
-				 * towards).
-				 */
-				break;
-			}
+			/* Load the first hop after the peer, rebuilt from
+			 * the getroutes path[0] we extracted earlier.
+			 *
+			 * We always probe with a short two-hop route (hop
+			 * 0 above, and this hop 1).  This gives the peer
+			 * the "benefit of the doubt": we only probe the
+			 * peer and *its* direct peer for uptime and
+			 * capacity.  Still "realistic" since the
+			 * destinations were chosen as popular nodes (or
+			 * at least to nodes that CLBOSS thinks are good
+			 * to have capacity towards).
+			 */
+			routearr.start_object()
+					.field("id", std::string(id1))
+					.field("channel", std::string(chan1))
+					.field("direction", direction1)
+					.field("amount_msat", amount1.to_msat())
+					.field("delay", delay1)
+					.field("style", "tlv")
+				.end_object();
 			routearr.end_array();
 
 			auto label = label_prefix + std::string(hash);

--- a/Boss/Mod/ChannelCandidateMatchmaker.cpp
+++ b/Boss/Mod/ChannelCandidateMatchmaker.cpp
@@ -93,27 +93,55 @@ private:
 		auto target = std::move(guide.front());
 		guide.pop();
 
+		auto probe_amount = 2.0 * min_channel;
 		auto parms = Json::Out()
 			.start_object()
-				.field("id", std::string(target))
-				.field("fromid", std::string(proposal))
-				/* 2x because the dowser will halve the channel
-				 * capacity of the first hop.
+				.field("source", std::string(proposal))
+				.field("destination", std::string(target))
+				/* 2x min_channel because the dowser will
+				 * halve the channel capacity of the first
+				 * hop.
 				 */
-				.field("amount_msat", (2.0 * min_channel).to_msat())
-				/* No real idea how to think about
-				 * riskfactor.
+				.field("amount_msat", probe_amount.to_msat())
+				/* No layers: source is a remote node
+				 * (proposal), not us, so the
+				 * auto.localchans / auto.sourcefree
+				 * helpers do not apply -- they would
+				 * inject our private local channels and
+				 * zero out the source's outgoing fees,
+				 * either of which could make askrene
+				 * pick a patron that the proposal cannot
+				 * actually reach via public topology.
 				 */
-				.field("riskfactor", 10)
-				.field("fuzzpercent", 0)
+				.start_array("layers").end_array()
+				/* Generous max-fee tolerance for what is a
+				 * route-discovery probe, not an actual
+				 * payment.
+				 */
+				.field("maxfee_msat",
+				       (probe_amount * 0.01).to_msat())
+				.field("final_cltv", 14)
+				.field("maxparts", 1)
 			.end_object()
 			;
-		return rpc.command("getroute", std::move(parms)
+		return rpc.command("getroutes", std::move(parms)
 				  ).then([this](Jsmn::Object res) {
 			auto patron = Ln::NodeId();
 			try {
+				/* getroutes' path[K].node_id_out was added
+				 * v26.06; the deprecated old name is
+				 * next_node_id, kept through v27.06 except
+				 * when developer mode suppresses
+				 * deprecated outputs.  Prefer the new
+				 * name, fall back to the old.  TODO: drop
+				 * the fallback once v26.04 is no longer
+				 * supported.
+				 */
+				auto path0 = res["routes"][0]["path"][0];
 				patron = Ln::NodeId(std::string(
-					res["route"][0]["id"]
+					path0.has("node_id_out")
+						? path0["node_id_out"]
+						: path0["next_node_id"]
 				));
 			} catch (Jsmn::TypeError const&) {
 				auto os = std::ostringstream();
@@ -121,11 +149,11 @@ private:
 				return Boss::log( bus, Error
 						, "ChannelCandidateMatchmaker:"
 						  " Unexpected result from "
-						  "getroute: %s"
+						  "getroutes: %s"
 						, os.str().c_str()
 						).then([]()
 							-> Ev::Io<void>{
-					throw RpcError( "getroute"
+					throw RpcError( "getroutes"
 						      , Jsmn::Object()
 						      );
 				});

--- a/Boss/Mod/ChannelCreateDestroyMonitor.cpp
+++ b/Boss/Mod/ChannelCreateDestroyMonitor.cpp
@@ -173,7 +173,17 @@ void ChannelCreateDestroyMonitor::start() {
 		try {
 			auto payload = params["channel_state_changed"];
 			n = Ln::NodeId(std::string(payload["peer_id"]));
-			old_state = std::string(payload["old_state"]);
+			/* `old_state` may be omitted: as of CLN v26.06 the
+			 * previously-deprecated sentinel value "unknown"
+			 * is no longer emitted; the field is simply
+			 * absent instead.  Leave old_state as the empty
+			 * string in that case -- the CHANNELD_NORMAL /
+			 * CHANNELD_AWAITING_LOCKIN check below will not
+			 * match, so we skip silently, matching the
+			 * original intent for the "unknown" value.
+			 */
+			if (payload.has("old_state"))
+				old_state = std::string(payload["old_state"]);
 			new_state = std::string(payload["new_state"]);
 		} catch (std::runtime_error const& err) {
 			return Boss::log( bus, Error

--- a/Boss/Mod/Dowser.cpp
+++ b/Boss/Mod/Dowser.cpp
@@ -12,18 +12,15 @@
 #include"Boss/concurrent.hpp"
 #include"Boss/log.hpp"
 #include"Ev/Io.hpp"
-#include"Ev/map.hpp"
 #include"Ev/yield.hpp"
 #include"Jsmn/Object.hpp"
 #include"Json/Out.hpp"
 #include"Ln/CommandId.hpp"
-#include"Ln/Scid.hpp"
 #include"S/Bus.hpp"
 #include"Util/make_unique.hpp"
 #include<assert.h>
 #include<memory>
 #include<string>
-#include<vector>
 
 namespace {
 
@@ -35,10 +32,37 @@ Ev::Io<void> wait_for_rpc(Boss::Mod::Rpc*& rpc) {
 	});
 }
 
-/* Maximum number of routes to try.  */
-auto const dowser_limit = std::size_t(10);
-/* Maximum length of routes.  */
-auto const route_limit = std::size_t(3);
+/* Probe amount used to ask askrene whether the destination has at
+ * least this much usable flow available from the source.  Chosen
+ * comfortably above clboss-min-channel's 500_000 sat floor so the
+ * Janitor's threshold check has margin.
+ */
+auto const probe_amount = Ln::Amount::sat(1000000);
+
+/* Maximum number of paths askrene may use to split the probe across.
+ * Mirrors the iteration count of the previous loop-and-exclude
+ * algorithm so an aggregate estimate similar in magnitude is plausible
+ * on well-connected networks.
+ */
+auto const probe_maxparts = std::uint32_t(10);
+
+/* Maximum fee tolerance for the probe.  We are not actually paying,
+ * but askrene refuses routes whose total cost exceeds this, so set
+ * it generously to avoid spurious 206 errors masking real route
+ * availability.
+ */
+auto const probe_maxfee = Ln::Amount::sat(5000);
+
+/* Final-cltv to pass to askrene.  Arbitrary low value; we are
+ * probing, not paying.
+ */
+auto const probe_final_cltv = std::uint32_t(14);
+
+/* Reserve factor applied to the dowsed delivered amount.  Preserved
+ * from the legacy algorithm: 1% channel reserve plus 0.5% default
+ * `maxfeepercent` headroom.
+ */
+auto const reserve_factor = double(0.985);
 
 }
 
@@ -52,11 +76,8 @@ private:
 	Ln::NodeId toid;
 
 	Boss::Mod::Rpc* rpc;
-	Ln::NodeId self_id;
 
-	std::vector<std::string> excludes;
 	Ln::Amount amount;
-	std::size_t tries;
 
 public:
 	Run( S::Bus& bus_
@@ -67,16 +88,14 @@ public:
 	     , requester(requester_)
 	     , fromid(fromid_)
 	     , toid(toid_)
+	     , amount(Ln::Amount::sat(0))
 	     { }
 
-	Ev::Io<void> run( Boss::Mod::Rpc& rpc_
-			, Ln::NodeId const& self_id_
-			) {
+	Ev::Io<void> run(Boss::Mod::Rpc& rpc_) {
 		rpc = &rpc_;
-		self_id = self_id_;
 		auto self = shared_from_this();
 		return Ev::lift().then([self]() {
-			return self->core_run();
+			return self->probe();
 		}).then([self]() {
 			return self->bus.raise(Msg::ResponseDowser{
 				self->requester, self->amount
@@ -85,175 +104,57 @@ public:
 	}
 
 private:
-	Ev::Io<void> core_run() {
-		return Ev::lift().then([this]() {
-			amount = Ln::Amount::sat(0);
-			tries = 0;
-			excludes.emplace_back(std::string(self_id));
-			return loop();
-		});
-	}
-	struct RouteStep {
-		Ln::Scid chan;
-		Ln::NodeId node;
-	};
-	Ev::Io<void> loop() {
-		return Ev::yield().then([this]() {
-			return getroute();
-		}).then([this](std::vector<RouteStep> route) {
-			if (route.empty())
-				/* Nothing to do now.  */
-				return Ev::lift();
-			add_exclude(route);
-			return get_capacity( std::move(route)
-					   ).then([this](Ln::Amount amt) {
-				/* Deduct 1.5% from the capacity, to
-				 * factor in 1% reserve and 0.5%
-				 * default `maxfeepercent`.
-				 */
-				amount += amt * 0.985;
-				++tries;
-				if (tries >= dowser_limit)
-					return Ev::lift();
-				return loop();
-			});
-		});
-	}
-	Ev::Io<std::vector<RouteStep>> getroute() {
-		auto exc = get_excludes();
+	/* Ask askrene whether `probe_amount` can flow from fromid to
+	 * toid; on success, the response's `routes` collectively deliver
+	 * that amount and we report it (less `reserve_factor`) as the
+	 * dowsed capacity.  Replaces the legacy 10-iteration
+	 * getroute+listchannels loop -- askrene's min-cost-flow solver
+	 * does multi-path enumeration natively (CLN >= v24.08, getroutes).
+	 */
+	Ev::Io<void> probe() {
 		auto params = Json::Out()
 			.start_object()
-				.field("id", std::string(toid))
-				.field("fromid", std::string(fromid))
-				.field("amount_msat", 1)
-				/* I never had a decent grasp of
-				 * riskfactor.  */
-				.field("riskfactor", 10.0)
-				.field("exclude", exc)
-				.field("fuzzpercent", 0.0)
-				.field("maxhops", route_limit)
+				.field("source", std::string(fromid))
+				.field("destination", std::string(toid))
+				.field("amount_msat", probe_amount.to_msat())
+				.start_array("layers")
+					.entry("auto.localchans")
+					.entry("auto.sourcefree")
+				.end_array()
+				.field("maxfee_msat", probe_maxfee.to_msat())
+				.field("final_cltv", probe_final_cltv)
+				.field("maxparts", probe_maxparts)
 			.end_object()
 			;
-		return rpc->command( "getroute"
+		return rpc->command( "getroutes"
 				   , std::move(params)
-				   ).then([](Jsmn::Object res) {
-			auto rv = std::vector<RouteStep>();
-			auto empty = std::vector<RouteStep>();
-
-			/* Parse result.  */
-			if (!res.is_object() || !res.has("route"))
-				return Ev::lift(empty);
-			auto route = res["route"];
-			if (!route.is_array())
-				return Ev::lift(empty);
-			for (auto step : route) {
-				if (!step.is_object())
-					return Ev::lift(empty);
-				if (!step.has("id"))
-					return Ev::lift(empty);
-				if (!step.has("channel"))
-					return Ev::lift(empty);
-
-				auto id_j = step["id"];
-				auto chan_j = step["channel"];
-				if (!id_j.is_string())
-					return Ev::lift(empty);
-				auto id_s = std::string(id_j);
-				if (!Ln::NodeId::valid_string(id_s))
-					return Ev::lift(empty);
-				auto id = Ln::NodeId(id_s);
-
-				if (!chan_j.is_string())
-					return Ev::lift(empty);
-				auto chan_s = std::string(chan_j);
-				if (!Ln::Scid::valid_string(chan_s))
-					return Ev::lift(empty);
-				auto chan = Ln::Scid(chan_s);
-
-				rv.emplace_back(RouteStep{chan, id});
+				   ).then([this](Jsmn::Object res) {
+			auto delivered = Ln::Amount::sat(0);
+			if (res.is_object() && res.has("routes")) {
+				auto routes = res["routes"];
+				if (routes.is_array()) {
+					for (auto r : routes) {
+						if ( !r.is_object()
+						  || !r.has("amount_msat")
+						   )
+							continue;
+						auto amt_j = r["amount_msat"];
+						if (!Ln::Amount::valid_object(amt_j))
+							continue;
+						delivered += Ln::Amount::object(amt_j);
+					}
+				}
 			}
-
-			return Ev::lift(std::move(rv));
-		}).catching<RpcError>([](RpcError const& _) {
-			/* Assume this is route-not-found.  */
-			return Ev::lift(std::vector<RouteStep>());
-		});
-	}
-	Json::Out get_excludes() {
-		auto json = Json::Out();
-		auto arr = json.start_array();
-		for (auto const& e : excludes)
-			arr.entry(e);
-		arr.end_array();
-		return json;
-	}
-
-	/* Given a route, adds an exclusion for the first part of
-	 * the route.  */
-	void add_exclude(std::vector<RouteStep> const& route) {
-		assert(!route.empty());
-		if (route.size() == 1) {
-			/* Exclude both directions of the first channel.  */
-			auto s = std::string(route[0].chan);
-			excludes.emplace_back(s + "/1");
-			excludes.emplace_back(s + "/0");
-		} else {
-			/* Exclude first node.  */
-			excludes.emplace_back(std::string(route[0].node));
-		}
-	}
-	/* Gets the capacity of a route.  */
-	Ev::Io<Ln::Amount> get_capacity(std::vector<RouteStep> route) {
-		assert(!route.empty());
-		using std::placeholders::_1;
-		return Ev::map( std::bind(&Run::get_1_capacity, this, _1)
-			      , route
-			      ).then([](std::vector<Ln::Amount> amounts) {
-			/* Get the smallest amount.  */
-			auto theoretical_capacity =
-				*std::min_element( amounts.begin()
-						 , amounts.end()
-						 );
-			/* Divide by number of hops + 1.  */
-			auto plausible_capacity =
-				theoretical_capacity / (amounts.size() + 1);
-			return Ev::lift(plausible_capacity);
-		});
-	}
-	/* Gets the capacity of a single route hop.  */
-	Ev::Io<Ln::Amount> get_1_capacity(RouteStep const& step) {
-		auto scid = std::string(step.chan);
-		return rpc->command( "listchannels"
-				   , Json::Out()
-					.start_object()
-						.field( "short_channel_id"
-						      , scid
-						      )
-					.end_object()
-				   ).then([](Jsmn::Object res) {
-			auto zero = Ln::Amount::sat(0);
-			if (!res.is_object() || !res.has("channels"))
-				return Ev::lift(zero);
-			auto chans = res["channels"];
-			if (!chans.is_array())
-				return Ev::lift(zero);
-			for (auto chan : chans) {
-				if ( !chan.is_object()
-				  || !chan.has("amount_msat")
-				   )
-					continue;
-				auto amt_j = chan["amount_msat"];
-				if (!Ln::Amount::valid_object(amt_j))
-					continue;
-				return Ev::lift(Ln::Amount::object(amt_j));
-			}
-
-			/* The channel *can* disappear between the time
-			 * we did `getroute` to the time we did
-			 * `listchannels`, so if we reach here, treat
-			 * this as 0-capacity.
+			amount = delivered * reserve_factor;
+			return Ev::lift();
+		}).catching<RpcError>([this](RpcError const& _) {
+			/* getroutes errors -- including 205 "Unable to
+			 * find a route" and 206 "Route too expensive" --
+			 * are the askrene way of saying "no flow"; map
+			 * them all to 0msat.
 			 */
-			return Ev::lift(zero);
+			amount = Ln::Amount::sat(0);
+			return Ev::lift();
 		});
 	}
 };
@@ -339,7 +240,6 @@ void Dowser::start() {
 	bus.subscribe<Msg::Init
 		     >([this](Msg::Init const& init) {
 		rpc = &init.rpc;
-		self_id = init.self_id;
 		return Ev::lift();
 	});
 	bus.subscribe<Msg::RequestDowser
@@ -350,7 +250,7 @@ void Dowser::start() {
 		return Ev::lift().then([this]() {
 			return wait_for_rpc(rpc);
 		}).then([this, run]() {
-			return Boss::concurrent(run->run(*rpc, self_id));
+			return Boss::concurrent(run->run(*rpc));
 		});
 	});
 
@@ -361,7 +261,6 @@ Dowser::~Dowser() =default;
 Dowser::Dowser(S::Bus& bus_
 	      ) : bus(bus_)
 		, rpc(nullptr)
-		, self_id()
 		{ start(); }
 
 }}

--- a/Boss/Mod/Dowser.hpp
+++ b/Boss/Mod/Dowser.hpp
@@ -1,7 +1,6 @@
 #ifndef BOSS_MOD_DOWSER_HPP
 #define BOSS_MOD_DOWSER_HPP
 
-#include"Ln/NodeId.hpp"
 #include<memory>
 
 namespace Boss { namespace Mod { class Rpc; }}
@@ -19,7 +18,6 @@ class Dowser {
 private:
 	S::Bus& bus;
 	Boss::Mod::Rpc* rpc;
-	Ln::NodeId self_id;
 
 	class CommandImpl;
 	std::unique_ptr<CommandImpl> cmdimpl;

--- a/Boss/Mod/NewaddrHandler.cpp
+++ b/Boss/Mod/NewaddrHandler.cpp
@@ -32,10 +32,18 @@ void NewaddrHandler::start() {
 	});
 }
 Ev::Io<void> NewaddrHandler::newaddr(void* requester) {
+	/** BREAKING CHANGE:
+	 * Requesting addresstype=p2tr is NOT compatible with CLN v23.05
+	 * and older, which did not accept the p2tr addresstype. */
+	auto params = Json::Out()
+		.start_object()
+			.field("addresstype", "p2tr")
+		.end_object()
+		;
 	return rpc->command( "newaddr"
-			   , Json::Out::empty_object()
+			   , std::move(params)
 			   ).then([this, requester](Jsmn::Object res) {
-		auto addr = std::string(res["bech32"]);
+		auto addr = std::string(res["p2tr"]);
 		return bus.raise(Msg::ResponseNewaddr{
 			std::move(addr), requester
 		});

--- a/Makefile.am
+++ b/Makefile.am
@@ -599,6 +599,7 @@ TESTS = \
 	tests/boss/channelcandidateinvestigator/test_gumshoe \
 	tests/boss/channelcandidateinvestigator/test_secretary \
 	tests/boss/test_availablerpccommandsannouncer \
+	tests/boss/test_channel_create_destroy_monitor_missing_old_state \
 	tests/boss/test_channelcreationdecider \
 	tests/boss/test_channelcreator_planner \
 	tests/boss/test_channelcreator_rearrangerbysize \

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+# Codecov configuration for CLBOSS.
+#
+# Project-level: still guards against bulk coverage regression
+# (overall coverage may not drop more than 1% from the master
+# baseline).
+#
+# Patch-level: informational only.  Most CLBOSS modules predate
+# the unit-test infrastructure and have no existing tests, so
+# requiring a fixed minimum patch coverage on every PR would
+# block work in those modules regardless of correctness.
+# Codecov still reports the per-PR coverage delta as a comment;
+# it just does not fail the status check.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true

--- a/tests/boss/test_channel_create_destroy_monitor_missing_old_state.cpp
+++ b/tests/boss/test_channel_create_destroy_monitor_missing_old_state.cpp
@@ -1,0 +1,101 @@
+#undef NDEBUG
+#include"Boss/Mod/ChannelCreateDestroyMonitor.hpp"
+#include"Boss/Msg/ChannelDestruction.hpp"
+#include"Boss/Msg/ListpeersAnalyzedResult.hpp"
+#include"Boss/Msg/Notification.hpp"
+#include"Boss/Shutdown.hpp"
+#include"Ev/Io.hpp"
+#include"Ev/start.hpp"
+#include"Ev/yield.hpp"
+#include"Jsmn/Object.hpp"
+#include"Ln/NodeId.hpp"
+#include"S/Bus.hpp"
+#include<assert.h>
+#include<memory>
+#include<string>
+
+/* Regression test for the CLN v26.06 compatibility branch in
+ * Boss::Mod::ChannelCreateDestroyMonitor that tolerates
+ * channel_state_changed notifications without an old_state field.
+ *
+ * Pre-v26.06 CLN emitted old_state="unknown" when a channel had
+ * no prior state.  v25.05 deprecated that sentinel and v26.06+
+ * drops the old_state field entirely on the same case.  The
+ * handler must:
+ *   - not throw on the missing field,
+ *   - not emit a ChannelDestruction event (matching the legacy
+ *     "unknown" behaviour, where the CHANNELD_NORMAL /
+ *     CHANNELD_AWAITING_LOCKIN check would never have matched
+ *     "unknown" either).
+ */
+
+int main() {
+	auto bus = S::Bus();
+	auto monitor = Boss::Mod::ChannelCreateDestroyMonitor(bus);
+
+	auto destruction_count = std::make_shared<int>(0);
+	bus.subscribe<Boss::Msg::ChannelDestruction
+		     >([destruction_count](Boss::Msg::ChannelDestruction const& _) {
+		*destruction_count = *destruction_count + 1;
+		return Ev::lift();
+	});
+
+	auto const peer_str = std::string(
+		"020000000000000000000000000000000000000000000000000000000000000000"
+	);
+	auto peer = Ln::NodeId(peer_str);
+
+	auto code = Ev::lift().then([&]() {
+		/* Seed the monitor's channeled set with `peer` and
+		 * mark initted = true.  Without this, the
+		 * notification handler would block in
+		 * wait_for_true(initted).
+		 */
+		auto r = Boss::Msg::ListpeersAnalyzedResult{};
+		r.connected_channeled.insert(peer);
+		r.initial = true;
+		return bus.raise(std::move(r));
+	}).then([&]() {
+		/* Build a channel_state_changed notification with
+		 * NO old_state field -- the v26.06+ shape.
+		 * new_state arbitrary; if the handler incorrectly
+		 * parsed an empty old_state as matching one of the
+		 * destruction-trigger states, we would see a
+		 * ChannelDestruction event.
+		 */
+		auto json = std::string(
+			"{\"channel_state_changed\":{"
+				"\"peer_id\":\""
+		) + peer_str + "\","
+			"\"new_state\":\"ONCHAIN\""
+			"}}";
+		auto params = Jsmn::Object::parse_json(json.c_str());
+		return bus.raise(Boss::Msg::Notification{
+			std::string("channel_state_changed"),
+			params
+		});
+	}).then([&]() {
+		/* Pump a few event-loop ticks so the handler's
+		 * wait_for_true polling and subsequent body run.
+		 */
+		return Ev::yield()
+		     + Ev::yield()
+		     + Ev::yield()
+		     + Ev::yield();
+	}).then([&]() {
+		return bus.raise(Boss::Shutdown{});
+	}).then([]() {
+		return Ev::lift(0);
+	});
+
+	auto ec = Ev::start(code);
+	assert(ec == 0);
+
+	/* The destruction handler must NOT have fired.  empty
+	 * old_state matches neither "CHANNELD_NORMAL" nor
+	 * "CHANNELD_AWAITING_LOCKIN", so the handler returns
+	 * Ev::lift() without doing anything.
+	 */
+	assert(*destruction_count == 0);
+	return 0;
+}


### PR DESCRIPTION
## Summary

CLN v26.06 deprecates `getroute` (last supported v27.03) and
removes the `"unknown"` sentinel value from
`channel_state_changed.old_state`.  Under `developer=true` or
`allow-deprecated-apis=false`, these become hard errors that
silently break CLBOSS subsystems that rely on them.

This PR migrates the three read-only `getroute` call sites in
CLBOSS to askrene-backed `getroutes`, and adds a defensive read
for the omitted notification field.

- **Dowser**: replaces the 10-iteration `getroute`+`listchannels`
  loop with a single `getroutes maxparts=N` call.
- **Matchmaker + ActiveProber**: `maxparts=1` swaps; field reads
  bridged across the v26.06 path[] hop rename so the code works
  on both v26.04 (old names only) and v26.06+ in developer mode
  (new names only).
- **ChannelCreateDestroyMonitor**: tolerate the omitted
  `old_state` field.

The fourth `getroute` caller (`FundsMover/Attempter`) needs a
redesign around `askrene-inform-channel` and is the subject of
the next stacked PR.  The `pay → xpay` migration follows after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Migrate three read-only getroute callers to askrene-backed getroutes for CLN v26.06 compatibility: Dowser, Matchmaker, and ActiveProber (FundsMover/Attempter deferred; pay→xpay planned).
- Dowser: replace iterative getroute+listchannels probing with a single getroutes (maxparts=N) call, sum routes[].amount_msat, apply a 1.5% reserve, map RpcError → 0, remove exclude/self_id plumbing, and reduce RPC roundtrips.
- Matchmaker & ActiveProber: use getroutes (maxparts=1) and tolerate hop-field-name differences (node_id_out ↔ next_node_id); ActiveProber reconstructs a sendpay-compatible first hop from path[0] (parsing short_channel_id_dir) and drops storing the raw Jsmn::Object route; ChannelCreateDestroyMonitor now tolerates a missing old_state by treating it as absent/no-op.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ksedgwic/clboss/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->