### PR TITLE
cln-v26.06-compat: InvoicePayer pay -> xpay

### DIFF
--- a/Boss/Mod/InvoicePayer.cpp
+++ b/Boss/Mod/InvoicePayer.cpp
@@ -8,28 +8,22 @@
 #include"Ev/foreach.hpp"
 #include"Jsmn/Object.hpp"
 #include"Json/Out.hpp"
+#include"Ln/Amount.hpp"
 #include"S/Bus.hpp"
-#include"Util/Str.hpp"
 #include<memory>
 
 namespace {
 
-/* The `maxfeepercent` setting to pass to `pay`.  */
-auto const nonmpp_maxfeepercent = 0.5;
-auto const mpp_maxfeepercent = 5.0;
-/* Wait, 5%??
- * Actually as of 0.9.0, 0.9.0-1, and 0.9.1, the MPP split
- * payment tends to badly mismanage the fee budget, and in
- * practice specifying 5% tends to lead to fees of less than
- * 1%.
- * But if you specify max fee of 1%, for badly-connected
- * nodes you have low chance of success since some of the
- * straggling payment parts are unable to reach the target
- * with the very minimal amount of budget they happened to
- * have gotten.
- * Until `lightningd` can fix the MPP budget handling, we
- * need to use this budget.
+/* Maximum routing fee we are willing to pay, expressed as a
+ * divisor of the invoice amount.  200 = 0.5% cap, preserving the
+ * historical pre-xpay `pay` non-MPP behaviour (xpay's own default
+ * would be 1%).  Integer math: maxfee_msat = amount_msat / 200,
+ * avoiding the rounding drift a 0.005 floating-point multiplication
+ * would introduce on larger invoices.  The only producer of
+ * Msg::PayInvoice is SwapManager paying a Boltz swap-out invoice,
+ * so tight fee discipline matters here.
  */
+auto constexpr maxfee_divisor = std::uint64_t(200);
 
 }
 
@@ -79,25 +73,20 @@ Ev::Io<void> InvoicePayer::pay(std::string n_invoice) {
 		|| !res.has("valid")
 		|| !res["valid"].is_boolean()
 		|| !bool(res["valid"])
+		|| !res.has("amount_msat")
 		) {
 			throw Jsmn::TypeError();
 		}
 
-		/* Check the features and see if this is MPP-enabled.  */
-		auto is_mpp = false;
-		if (res.has("features")) {
-			auto features_s = std::string(res["features"]);
-			auto features = Util::Str::hexread(features_s);
-			/* Basic MPP is bits 16 or 17.  */
-			if (features.size() >= 3) {
-				if (features[features.size() - 3] & 0x03)
-					is_mpp = true;
-			}
-		}
+		/* Compute an absolute maxfee from the invoice amount,
+		 * preserving the historical 0.5% cap via integer
+		 * division.  xpay's MPP handling makes the legacy
+		 * feature-bit-driven MPP branch unnecessary: askrene
+		 * + xpay manage the fee budget across parts internally.
+		 */
+		auto amount = Ln::Amount::object(res["amount_msat"]);
+		auto maxfee_msat = amount.to_msat() / maxfee_divisor;
 
-		auto maxfeepercent =
-			(is_mpp) ?	mpp_maxfeepercent :
-			/*otherwise*/	nonmpp_maxfeepercent ;
 		/* TODO: Get created_at and expiry, add them, then determine
 		 * current time and subtract, to get retry_for.
 		 */
@@ -105,12 +94,12 @@ Ev::Io<void> InvoicePayer::pay(std::string n_invoice) {
 
 		auto parms = Json::Out()
 			.start_object()
-				.field("bolt11", *inv)
+				.field("invstring", *inv)
 				.field("retry_for", retry_for)
-				.field("maxfeepercent", maxfeepercent)
+				.field("maxfee", maxfee_msat)
 			.end_object()
 			;
-		return rpc->command("pay", std::move(parms));
+		return rpc->command("xpay", std::move(parms));
 	}).then([this, inv](Jsmn::Object _) {
 		return Boss::log( bus, Debug
 				, "InvoicePayer: Paid: %s"
@@ -125,12 +114,6 @@ Ev::Io<void> InvoicePayer::pay(std::string n_invoice) {
 		return Boss::log( bus, Error
 				, "InvoicePayer: "
 				  "Unexpected decode result for invoice: %s"
-				, inv->c_str()
-				);
-	}).catching<Util::Str::HexParseFailure>([this, inv](Util::Str::HexParseFailure const& _) {
-		return Boss::log( bus, Error
-				, "InvoicePayer: "
-				  "Unexpected 'features' for invoice: %s"
 				, inv->c_str()
 				);
 	});

--- a/tests/boss/test_invoicepayer_decodepay.cpp
+++ b/tests/boss/test_invoicepayer_decodepay.cpp
@@ -194,17 +194,17 @@ public:
 			})");
 		}).then([this, invoice]() {
 			return read_request().then([this, invoice](Jsmn::Object req) {
-				auto id = assert_method(req, "pay");
+				auto id = assert_method(req, "xpay");
 				auto params = req["params"];
 				assert(params.is_object());
-				assert(params.has("bolt11"));
-				assert(std::string(params["bolt11"]) == invoice);
+				assert(params.has("invstring"));
+				assert(std::string(params["invstring"]) == invoice);
 				assert(params.has("retry_for"));
 				assert(params["retry_for"].is_number());
 				assert(double(params["retry_for"]) == 1000.0);
-				assert(params.has("maxfeepercent"));
-				assert(params["maxfeepercent"].is_number());
-				assert(double(params["maxfeepercent"]) == 5.0);
+				assert(params.has("maxfee"));
+				assert(params["maxfee"].is_number());
+				assert(double(params["maxfee"]) == 5000.0);
 				return reply_result(id, "{}");
 			}).then([this]() {
 				*pay_replied = true;


### PR DESCRIPTION
## Summary

Stacked on top of #315  (`cln-v26.06-compat: FundsMover failure
feedback via askrene layer`).

`pay` was deprecated in CLN v26.06 (last supported v27.03,
tighter window than `getroute`'s v27.06).  Its replacement
`xpay` has been available since v24.11, so this is a straight
migration with no compatibility bridge required.

The sole producer of `Msg::PayInvoice` is `SwapManager` paying a
Boltz swap-out invoice (`Boss/Mod/SwapManager.cpp:541`), so this
code path is exclusively swap-out invoice payment -- real money
on prod.

- `pay` -> `xpay`, request field `bolt11` -> `invstring`.
- `maxfeepercent` (a percentage) replaced by `maxfee` (an
  absolute msat amount) computed from the decoded invoice
  amount.  The 0.5% fraction preserves the legacy non-MPP
  fee cap; xpay's own default of 1% would have doubled our
  historical fee budget, which matters for swap-out economics.
- Drop the MPP feature-bit detection (hex-parsing the bolt11
  features string).  It existed solely to pick between two
  `maxfeepercent` values for pre-xpay `pay`, whose pre-v0.10
  MPP fee-budget management required a generous 5% cap to
  succeed.  xpay's askrene-driven multi-path routing manages
  its own per-part budget.
- Drop the `Util::Str::HexParseFailure` catch path (no longer
  reachable) and the `Util/Str.hpp` include.

InvoicePayer reads no fields from the response (consumed as
`Jsmn::Object _`), so xpay's response-shape differences vs pay
are not visible at this caller.

CLN minimum unchanged from #314/#315 (xpay landed v24.11,
contemporaneous with askrene-create-layer/inform-channel).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Migrates InvoicePayer from deprecated CLN `pay` RPC method to `xpay`, updating the request field from `bolt11` to `invstring` and computing an absolute `maxfee` (in msat) from the decoded invoice amount using a 0.5% cap instead of percentage-based `maxfeepercent`.
- Removes MPP feature-bit detection logic and associated hex-parsing error handling (`Util::Str::hexread`), since fee-cap selection is no longer needed with `xpay`.
- Test assertions updated to validate `xpay` request parameters (`invstring`, `retry_for: 1000`, and `maxfee: 5000`) instead of the prior `pay` parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ksedgwic/clboss/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->