### PR TITLE
cln-v26.06-compat: ActiveProber: feed the clboss askrene layer

### DIFF
--- a/Boss/Mod/ActiveProber.cpp
+++ b/Boss/Mod/ActiveProber.cpp
@@ -1,4 +1,5 @@
 #include"Boss/Mod/ActiveProber.hpp"
+#include"Boss/Mod/AskreneLayer.hpp"
 #include"Boss/Mod/ChannelCandidateInvestigator/Main.hpp"
 #include"Boss/Mod/Rpc.hpp"
 #include"Boss/Msg/Init.hpp"
@@ -448,6 +449,138 @@ private:
 		return sendpay();
 	}
 
+	/* Parse waitsendpay's error data and return whether the probe
+	 * should be considered successful.  Side effect: on real
+	 * route failures, write to the persistent clboss askrene
+	 * layer so future getroutes calls steer around the failing
+	 * channel/node.
+	 *
+	 * Probe-success outcome: the final hop (id1) replied with
+	 * WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS (failcode
+	 * 0x400F), which is the expected failure given our
+	 * bit-flipped random payment_hash and proves the route
+	 * worked all the way through to id1.
+	 *
+	 * Failure outcomes that feed the layer:
+	 *   - Code 202 (unparsable onion): cannot pin a specific
+	 *     channel; disable id1 as the best-guess culprit on
+	 *     this 2-hop route.
+	 *   - NODE-level failcode (bit 0x2000 set): disable the
+	 *     erring_node.
+	 *   - CHANNEL-level failcode on a non-chan0 channel
+	 *     (= chan1): inform_channel_constrained at amount1.
+	 *
+	 * Failures we DO NOT feed:
+	 *   - echan == chan0: our local outgoing channel had the
+	 *     issue.  CLBOSS already has authoritative knowledge of
+	 *     local channel state via listpeerchannels; no need to
+	 *     re-record into the shared layer.
+	 *   - Unparseable error data: don't guess.
+	 */
+	Ev::Io<bool> record_failure(RpcError const& err) {
+		auto code = int();
+		auto eidx = std::size_t();
+		auto echan = Ln::Scid();
+		auto edir = std::uint32_t();
+		auto enode = Ln::NodeId();
+		auto fail = std::uint16_t();
+		auto parsed = false;
+		try {
+			auto& error = err.error;
+			code = int(double(error["code"]));
+			/* Both codes carry the same data shape but
+			 * different origin signal:
+			 *   203 = destination permanently failed
+			 *         (e.g. final-hop responded with
+			 *         WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS,
+			 *         the expected probe-success outcome).
+			 *   204 = intermediate failure ("try another route").
+			 */
+			if (code == 203 || code == 204) {
+				auto data = error["data"];
+				eidx = std::size_t(double(
+					data["erring_index"]
+				));
+				echan = Ln::Scid(std::string(
+					data["erring_channel"]
+				));
+				edir = std::uint32_t(double(
+					data["erring_direction"]
+				));
+				enode = Ln::NodeId(std::string(
+					data["erring_node"]
+				));
+				fail = std::uint16_t(double(
+					data["failcode"]
+				));
+				parsed = true;
+			}
+		} catch (std::exception const&) {
+			/* Couldn't parse; treat as real failure with
+			 * no layer feedback.  Avoid acting on garbage.
+			 */
+			return Ev::lift(false);
+		}
+		(void) eidx;  /* Currently unused; relying on echan and
+			       * failcode to discriminate.  Future:
+			       * cross-check eidx against expected route
+			       * positions if discrepancies emerge.
+			       */
+
+		auto const& layer_name =
+			Boss::Mod::AskreneLayer::clboss_layer_name;
+
+		if (code == 202) {
+			/* Unparsable onion: best guess on a 2-hop
+			 * probe is that id1 is the culprit.
+			 */
+			return Boss::Mod::AskreneLayer::disable_node(
+				rpc, layer_name, id1
+			).then([]() {
+				return Ev::lift(false);
+			});
+		}
+
+		if (!parsed) {
+			/* Other error code, no actionable hop info.  */
+			return Ev::lift(false);
+		}
+
+		/* WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS at the
+		 * destination is the expected probe outcome: id1
+		 * received the HTLC and rejected it because the
+		 * random bit-flipped payment_hash matches no
+		 * invoice.  The route was viable all the way.
+		 */
+		auto const WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS
+			= std::uint16_t(0x400F);
+		if (fail == WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS)
+			return Ev::lift(true);
+
+		/* Don't record local-channel failures.  */
+		if (echan == chan0)
+			return Ev::lift(false);
+
+		/* NODE-level: 0x2000 bit set.  */
+		if (fail & 0x2000) {
+			return Boss::Mod::AskreneLayer::disable_node(
+				rpc, layer_name, enode
+			).then([]() {
+				return Ev::lift(false);
+			});
+		}
+
+		/* CHANNEL-level failure on a non-chan0 channel
+		 * (= chan1).  Record an upper-bound constraint at
+		 * the amount that failed to push through.
+		 */
+		return Boss::Mod::AskreneLayer::inform_channel_constrained(
+			rpc, layer_name, echan, edir, amount1
+		).then([]() {
+			return Ev::lift(false);
+		});
+	}
+
 	Ev::Io<void> sendpay() {
 		return Ev::lift().then([this]() {
 			auto os = std::ostringstream();
@@ -523,9 +656,30 @@ private:
 			 * Should not happen though.
 			 */
 			return Ev::lift(true);
-		}).catching<RpcError>([](RpcError const& _) {
-			/* Oh no, we failed, as expected.  */
-			return Ev::lift(false);
+		}).catching<RpcError>([this](RpcError const& err) {
+			/* Inspect the error to determine: was this a
+			 * successful probe (id1 received the HTLC and
+			 * rejected it with
+			 * WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS as
+			 * expected given our bit-flipped random
+			 * payment_hash) or a real route failure?  Real
+			 * failures are recorded into the persistent
+			 * clboss askrene layer so future getroutes
+			 * calls steer around the failing channel/node.
+			 *
+			 * record_failure returns whether the probe was
+			 * useful (reached destination), but the bool
+			 * we hand downstream tracks sendpay-completion,
+			 * not probe-usefulness.  We are in the
+			 * RpcError handler, so the sendpay failed in
+			 * CLN's view regardless of how useful the
+			 * probe was -- delpay below must pass
+			 * status="failed" to match what CLN recorded.
+			 * Discard the probe-useful bit here.
+			 */
+			return record_failure(err).then([](bool) {
+				return Ev::lift(false);
+			});
 		}).then([this](bool success) {
 
 			auto status = std::string(

--- a/Boss/Mod/ActiveProber.cpp
+++ b/Boss/Mod/ActiveProber.cpp
@@ -551,11 +551,38 @@ private:
 		 * received the HTLC and rejected it because the
 		 * random bit-flipped payment_hash matches no
 		 * invoice.  The route was viable all the way.
+		 *
+		 * Record a positive lower-bound observation on chan1:
+		 * we just proved this directed channel can push at
+		 * least amount1 right now.  askrene's
+		 * inform=unconstrained mode stores this as a
+		 * constraint with min=amount, max=NULL -- exactly
+		 * the lower-bound raise we want for future getroutes
+		 * calls to trust this channel more.
+		 *
+		 * (Askrene also has an inform=succeeded mode but that
+		 * branch is currently a no-op stub in askrene.c
+		 * "FIXME: We could do something useful here!" -- so
+		 * we follow xpay's convention of using
+		 * inform=unconstrained for the post-success
+		 * lower-bound-raise pattern.)
+		 *
+		 * We do NOT record a parallel observation on chan0
+		 * (our outbound channel to peer).  CLBOSS already
+		 * has authoritative knowledge of local channel state
+		 * via listpeerchannels; the shared askrene layer is
+		 * for cross-subsystem knowledge that isn't already
+		 * locally available.
 		 */
 		auto const WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS
 			= std::uint16_t(0x400F);
-		if (fail == WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS)
-			return Ev::lift(true);
+		if (fail == WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS) {
+			return Boss::Mod::AskreneLayer::inform_channel_unconstrained(
+				rpc, layer_name, chan1, direction1, amount1
+			).then([]() {
+				return Ev::lift(true);
+			});
+		}
 
 		/* Don't record local-channel failures.  */
 		if (echan == chan0)

--- a/Boss/Mod/AskreneLayer.cpp
+++ b/Boss/Mod/AskreneLayer.cpp
@@ -1,0 +1,106 @@
+#include"Boss/Mod/AskreneLayer.hpp"
+#include"Boss/Mod/Rpc.hpp"
+#include"Ev/Io.hpp"
+#include"Jsmn/Object.hpp"
+#include"Json/Out.hpp"
+#include"Util/stringify.hpp"
+#include<assert.h>
+
+namespace Boss { namespace Mod { namespace AskreneLayer {
+
+std::string const clboss_layer_name = "clboss";
+
+namespace {
+
+/* Common machinery for the two inform_channel variants.  askrene
+ * accepts inform=succeeded / constrained / unconstrained as the
+ * only difference between them; everything else (scid_dir,
+ * amount_msat, layer) is identical.
+ */
+Ev::Io<void>
+inform_channel( Boss::Mod::Rpc& rpc
+	      , std::string const& layer
+	      , Ln::Scid scid
+	      , std::uint32_t direction
+	      , Ln::Amount amount
+	      , char const* inform
+	      ) {
+	/* askrene only accepts direction 0 or 1 in
+	 * short_channel_id_dir.  All callers feed values from
+	 * CLN's getroutes/sendpay responses, which are
+	 * guaranteed to be 0/1, but guard explicitly: a bad
+	 * direction would produce a syntactically valid but
+	 * semantically wrong RPC param that askrene rejects, and
+	 * the silent-swallow RpcError handler below would drop
+	 * the learning update without a trace.
+	 */
+	assert(direction <= 1);
+	if (direction > 1)
+		return Ev::lift();
+	auto sdir = std::string(scid) + "/" + Util::stringify(direction);
+	auto parms = Json::Out()
+		.start_object()
+			.field("layer", layer)
+			.field("short_channel_id_dir", sdir)
+			.field("amount_msat", amount.to_msat())
+			.field("inform", std::string(inform))
+		.end_object()
+		;
+	return rpc.command( "askrene-inform-channel"
+			  , std::move(parms)
+			  ).then([](Jsmn::Object _) {
+		return Ev::lift();
+	}).catching<RpcError>([](RpcError const&) {
+		/* Non-fatal -- if the layer is missing (e.g. layer-
+		 * create failed at startup on CLN < v24.11),
+		 * subsequent getroutes calls simply will not benefit
+		 * from the constraint.  Better to degrade learning
+		 * than to crash the caller.
+		 */
+		return Ev::lift();
+	});
+}
+
+}
+
+Ev::Io<void>
+inform_channel_constrained( Boss::Mod::Rpc& rpc
+			  , std::string const& layer
+			  , Ln::Scid scid
+			  , std::uint32_t direction
+			  , Ln::Amount amount
+			  ) {
+	return inform_channel(rpc, layer, scid, direction, amount, "constrained");
+}
+
+Ev::Io<void>
+inform_channel_unconstrained( Boss::Mod::Rpc& rpc
+			    , std::string const& layer
+			    , Ln::Scid scid
+			    , std::uint32_t direction
+			    , Ln::Amount amount
+			    ) {
+	return inform_channel(rpc, layer, scid, direction, amount, "unconstrained");
+}
+
+Ev::Io<void>
+disable_node( Boss::Mod::Rpc& rpc
+	    , std::string const& layer
+	    , Ln::NodeId node
+	    ) {
+	auto parms = Json::Out()
+		.start_object()
+			.field("layer", layer)
+			.field("node", std::string(node))
+		.end_object()
+		;
+	return rpc.command( "askrene-disable-node"
+			  , std::move(parms)
+			  ).then([](Jsmn::Object _) {
+		return Ev::lift();
+	}).catching<RpcError>([](RpcError const&) {
+		return Ev::lift();
+	});
+}
+
+}}}

--- a/Boss/Mod/AskreneLayer.hpp
+++ b/Boss/Mod/AskreneLayer.hpp
@@ -1,0 +1,74 @@
+#ifndef BOSS_MOD_ASKRENELAYER_HPP_
+#define BOSS_MOD_ASKRENELAYER_HPP_
+
+#include"Ev/Io.hpp"
+#include"Ln/Amount.hpp"
+#include"Ln/NodeId.hpp"
+#include"Ln/Scid.hpp"
+#include<cstdint>
+#include<string>
+
+namespace Boss { namespace Mod { class Rpc; } }
+
+namespace Boss { namespace Mod { namespace AskreneLayer {
+
+/* Name of the persistent askrene layer that CLBOSS subsystems
+ * write failure-feedback and (optionally) success-observations
+ * into.  Following the xpay convention -- the layer is named
+ * after the plugin that owns it.  All CLBOSS writes go to this
+ * layer; downstream getroutes calls that include it in their
+ * layers array benefit from the accumulated knowledge.
+ */
+extern std::string const clboss_layer_name;
+
+/* Tell askrene that a directed channel could not push at least
+ * the given amount recently.  Future getroutes calls that
+ * include the clboss layer will treat this as an upper-bound
+ * constraint and steer around it.  Non-fatal on RpcError: if
+ * the layer is missing (e.g. CLN < v24.11 where askrene layers
+ * are unavailable) the call silently completes -- failure-mode
+ * is degraded learning, not crashed caller.
+ */
+Ev::Io<void> inform_channel_constrained( Boss::Mod::Rpc& rpc
+				       , std::string const& layer
+				       , Ln::Scid scid
+				       , std::uint32_t direction
+				       , Ln::Amount amount
+				       );
+
+/* Tell askrene that a directed channel successfully pushed at
+ * least the given amount recently.  Future getroutes calls
+ * that include the layer will treat this as a lower-bound on
+ * the channel's capacity (min=amount, max=NULL).  Non-fatal
+ * on RpcError, same rationale as inform_channel_constrained.
+ *
+ * Naming note: this maps to askrene's `inform=unconstrained`
+ * mode (which means "no upper-bound; minimum is amount").
+ * Askrene also has an `inform=succeeded` mode but as of
+ * v26.06 that branch is a no-op stub in askrene.c
+ * (`FIXME: We could do something useful here!`).  xpay uses
+ * `inform=unconstrained` for the same after-success
+ * lower-bound-raise pattern (see plugins/xpay/xpay.c
+ * around `"We learned something about prior nodes"`).
+ */
+Ev::Io<void> inform_channel_unconstrained( Boss::Mod::Rpc& rpc
+					 , std::string const& layer
+					 , Ln::Scid scid
+					 , std::uint32_t direction
+					 , Ln::Amount amount
+					 );
+
+/* Tell askrene to avoid the given node entirely for routes
+ * that include this layer.  Used for NODE-level onion failures
+ * (failcode bit 0x2000) and for unparsable-onion fallback,
+ * where we cannot pin the failure to a specific channel.
+ * Non-fatal on RpcError.
+ */
+Ev::Io<void> disable_node( Boss::Mod::Rpc& rpc
+			 , std::string const& layer
+			 , Ln::NodeId node
+			 );
+
+}}}
+
+#endif /* !defined(BOSS_MOD_ASKRENELAYER_HPP_) */

--- a/Boss/Mod/FundsMover/Attempter.cpp
+++ b/Boss/Mod/FundsMover/Attempter.cpp
@@ -1,3 +1,4 @@
+#include"Boss/Mod/AskreneLayer.hpp"
 #include"Boss/Mod/FundsMover/Attempter.hpp"
 #include"Boss/Mod/FundsMover/create_label.hpp"
 #include"Boss/Mod/Rpc.hpp"
@@ -15,22 +16,6 @@
 #include<assert.h>
 #include<string>
 #include<vector>
-
-namespace {
-
-/* Name of the persistent askrene layer that holds CLBOSS's
- * failure-feedback knowledge -- channel capacity constraints
- * (askrene-inform-channel) and node-level exclusions
- * (askrene-disable-node) accumulated across attempts.  Created
- * idempotently at startup by Boss::Mod::FundsMover::Main.
- *
- * Naming follows the convention established by plugins/xpay
- * (which uses "xpay"): the persistent shared-knowledge layer is
- * named after the plugin that owns it.
- */
-auto const clboss_layer = std::string("clboss");
-
-}
 
 namespace Boss { namespace Mod { namespace FundsMover {
 
@@ -175,7 +160,7 @@ private:
 					.start_array("layers")
 						.entry("auto.localchans")
 						.entry("auto.sourcefree")
-						.entry(clboss_layer)
+						.entry(Boss::Mod::AskreneLayer::clboss_layer_name)
 					.end_array()
 					.field("maxfee_msat",
 					       route_maxfee.to_msat())
@@ -397,58 +382,6 @@ private:
 		});
 	}
 
-	/* Tell askrene about a failed-channel constraint so future
-	 * getroutes calls steer around it.  Recorded into the
-	 * persistent "clboss" layer; benefits all subsequent attempts
-	 * and (when they migrate to consume the same layer) other
-	 * CLBOSS subsystems too.
-	 */
-	Ev::Io<void> inform_channel_constrained( Ln::Scid scid
-					       , int dir
-					       , Ln::Amount at
-					       ) {
-		auto sdir = std::string(scid) + "/" + Util::stringify(dir);
-		auto parms = Json::Out()
-			.start_object()
-				.field("layer", clboss_layer)
-				.field("short_channel_id_dir", sdir)
-				.field("amount_msat", at.to_msat())
-				.field("inform", "constrained")
-			.end_object()
-			;
-		return rpc.command( "askrene-inform-channel"
-				  , std::move(parms)
-				  ).then([](Jsmn::Object _) {
-			return Ev::lift();
-		}).catching<RpcError>([](RpcError const&) {
-			/* Non-fatal -- if the layer is missing
-			 * (e.g. layer-create failed at startup on a
-			 * CLN < v24.11), subsequent getroutes calls
-			 * simply will not benefit from the constraint.
-			 */
-			return Ev::lift();
-		});
-	}
-
-	/* Tell askrene to avoid a node entirely; same persistent
-	 * layer.  Used for NODE-level onion failures (failcode bit
-	 * 0x2000) and for unparsable-onion fallback.
-	 */
-	Ev::Io<void> disable_node(Ln::NodeId node) {
-		auto parms = Json::Out()
-			.start_object()
-				.field("layer", clboss_layer)
-				.field("node", std::string(node))
-			.end_object()
-			;
-		return rpc.command( "askrene-disable-node"
-				  , std::move(parms)
-				  ).then([](Jsmn::Object _) {
-			return Ev::lift();
-		}).catching<RpcError>([](RpcError const&) {
-			return Ev::lift();
-		});
-	}
 
 	Ev::Io<void> sendpay() {
 		auto payment_hash = std::make_shared<Sha256::Hash>();
@@ -612,7 +545,11 @@ private:
 					     ;
 				/* 0x2000 == NODE level error.  */
 				if ((fail & 0x2000))
-					feedback = disable_node(enode);
+					feedback = Boss::Mod::AskreneLayer::disable_node(
+						rpc,
+						Boss::Mod::AskreneLayer::clboss_layer_name,
+						enode
+					);
 				else
 					/* The amount to pass to askrene-inform-channel
 					 * is the HTLC amount attempted on the specific
@@ -623,7 +560,9 @@ private:
 					 * [1, route.size()] here and route[eidx - 1]
 					 * describes the failing channel.
 					 */
-					feedback = inform_channel_constrained(
+					feedback = Boss::Mod::AskreneLayer::inform_channel_constrained(
+						rpc,
+						Boss::Mod::AskreneLayer::clboss_layer_name,
 						echan, edir,
 						route[eidx - 1].amount_msat
 					);

--- a/Boss/Mod/FundsMover/Main.cpp
+++ b/Boss/Mod/FundsMover/Main.cpp
@@ -1,3 +1,4 @@
+#include"Boss/Mod/AskreneLayer.hpp"
 #include"Boss/Mod/FundsMover/Claimer.hpp"
 #include"Boss/Mod/FundsMover/Main.hpp"
 #include"Boss/Mod/FundsMover/Runner.hpp"
@@ -133,7 +134,8 @@ private:
 		return Ev::lift().then([this]() {
 			auto parms = Json::Out()
 				.start_object()
-					.field("layer", "clboss")
+					.field("layer",
+					       Boss::Mod::AskreneLayer::clboss_layer_name)
 					.field("persistent", true)
 				.end_object()
 				;

--- a/Makefile.am
+++ b/Makefile.am
@@ -600,6 +600,7 @@ TESTS = \
 	tests/boltz/test_match_lockscript \
 	tests/boss/channelcandidateinvestigator/test_gumshoe \
 	tests/boss/channelcandidateinvestigator/test_secretary \
+	tests/boss/test_askrene_layer \
 	tests/boss/test_availablerpccommandsannouncer \
 	tests/boss/test_channel_create_destroy_monitor_missing_old_state \
 	tests/boss/test_channelcreationdecider \

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,8 @@ libclboss_la_SOURCES = \
 	Boss/Mod/ActiveProber.hpp \
 	Boss/Mod/AmountSettingsHandler.cpp \
 	Boss/Mod/AmountSettingsHandler.hpp \
+	Boss/Mod/AskreneLayer.cpp \
+	Boss/Mod/AskreneLayer.hpp \
 	Boss/Mod/AutoDisconnector.cpp \
 	Boss/Mod/AutoDisconnector.hpp \
 	Boss/Mod/AvailableRpcCommandsAnnouncer.cpp \

--- a/tests/boss/test_askrene_layer.cpp
+++ b/tests/boss/test_askrene_layer.cpp
@@ -1,0 +1,313 @@
+#undef NDEBUG
+#include"Boss/Mod/AskreneLayer.hpp"
+#include"Boss/Mod/Rpc.hpp"
+#include"Boss/Shutdown.hpp"
+#include"Ev/Io.hpp"
+#include"Ev/concurrent.hpp"
+#include"Ev/start.hpp"
+#include"Ev/yield.hpp"
+#include"Jsmn/Object.hpp"
+#include"Jsmn/Parser.hpp"
+#include"Json/Out.hpp"
+#include"Ln/Amount.hpp"
+#include"Ln/NodeId.hpp"
+#include"Ln/Scid.hpp"
+#include"Net/Fd.hpp"
+#include"S/Bus.hpp"
+#include<assert.h>
+#include<deque>
+#include<errno.h>
+#include<fcntl.h>
+#include<string>
+#include<sys/socket.h>
+#include<sys/types.h>
+#include<unistd.h>
+
+namespace {
+
+/* Minimal MockRpcServer: read one JSON-RPC request from the socket,
+ * stash it for the test to inspect, then reply with either a success
+ * result or an error.  Modelled on test_invoicepayer_decodepay.cpp.
+ */
+class MockRpcServer {
+private:
+	Net::Fd socket;
+	Jsmn::Parser parser;
+	std::deque<Jsmn::Object> requests;
+
+	Ev::Io<Jsmn::Object> read_request(std::size_t retries = 0) {
+		return Ev::yield().then([this]() {
+			if (requests.empty())
+				return Ev::lift(Jsmn::Object());
+			auto req = std::move(requests.front());
+			requests.pop_front();
+			return Ev::lift(std::move(req));
+		}).then([this, retries](Jsmn::Object req) {
+			if (!req.is_null())
+				return Ev::lift(std::move(req));
+			assert(retries < 100000);
+
+			char buf[512];
+			auto rd = ssize_t();
+			do {
+				rd = read(socket.get(), buf, sizeof(buf));
+			} while (rd < 0 && errno == EINTR);
+			if (rd < 0 && (errno == EWOULDBLOCK || errno == EAGAIN))
+				return read_request(retries + 1);
+			assert(rd > 0);
+
+			auto parsed = parser.feed(std::string(buf, std::size_t(rd)));
+			for (auto& p : parsed)
+				requests.push_back(std::move(p));
+			return read_request(retries + 1);
+		});
+	}
+
+	Ev::Io<void> write_all(std::string data, std::size_t retries = 0) {
+		return Ev::yield().then([this, data, retries]() {
+			auto wr = ssize_t();
+			do {
+				wr = write(socket.get(), data.c_str(), data.size());
+			} while (wr < 0 && errno == EINTR);
+			if (wr < 0 && (errno == EWOULDBLOCK || errno == EAGAIN))
+				return write_all(data, retries + 1);
+			assert(wr >= 0);
+			assert(retries < 100000);
+			if (std::size_t(wr) < data.size())
+				return write_all(data.substr(std::size_t(wr)),
+						retries + 1);
+			return Ev::lift();
+		});
+	}
+
+	Ev::Io<void> reply_ok(std::uint64_t id) {
+		auto response = Json::Out()
+			.start_object()
+				.field("jsonrpc", std::string("2.0"))
+				.field("id", double(id))
+				.start_object("result")
+				.end_object()
+			.end_object()
+			.output();
+		return write_all(std::move(response));
+	}
+
+	Ev::Io<void> reply_error(std::uint64_t id) {
+		auto response = Json::Out()
+			.start_object()
+				.field("jsonrpc", std::string("2.0"))
+				.field("id", double(id))
+				.start_object("error")
+					.field("code", double(-32000))
+					.field("message", std::string("test-induced failure"))
+				.end_object()
+			.end_object()
+			.output();
+		return write_all(std::move(response));
+	}
+
+public:
+	explicit MockRpcServer(Net::Fd socket_)
+		: socket(std::move(socket_)), parser(), requests() {
+		auto flags = fcntl(socket.get(), F_GETFL);
+		assert(flags >= 0);
+		flags |= O_NONBLOCK;
+		auto fcntl_result = fcntl(socket.get(), F_SETFL, flags);
+		assert(fcntl_result == 0);
+	}
+
+	/* Read the next request, hand to the asserter callback, then
+	 * reply with reply_ok.  Convenience wrapper for happy-path
+	 * tests.
+	 */
+	template <typename F>
+	Ev::Io<void> serve_ok(F asserter) {
+		return read_request().then([this, asserter = std::move(asserter)](Jsmn::Object req) mutable {
+			auto id = asserter(req);
+			return reply_ok(id);
+		});
+	}
+
+	/* Read the next request, run the asserter, then reply with an
+	 * RPC error.  For testing the silent-swallow path.
+	 */
+	template <typename F>
+	Ev::Io<void> serve_error(F asserter) {
+		return read_request().then([this, asserter = std::move(asserter)](Jsmn::Object req) mutable {
+			auto id = asserter(req);
+			return reply_error(id);
+		});
+	}
+};
+
+std::uint64_t assert_method(Jsmn::Object const& req, char const* method) {
+	assert(req.is_object());
+	assert(req.has("id"));
+	assert(req["id"].is_number());
+	assert(req.has("method"));
+	assert(req["method"].is_string());
+	assert(std::string(req["method"]) == method);
+	return std::uint64_t(double(req["id"]));
+}
+
+/* Test 1: inform_channel_constrained sends the expected JSON-RPC
+ * call shape and completes when the server replies success.
+ *
+ * Pattern (from test_rpc.cpp): server runs as Ev::concurrent in the
+ * background; the helper runs in the main chain.  When the helper
+ * completes, the chain ends -- no flag polling required.
+ */
+Ev::Io<void>
+test_inform_channel_constrained( MockRpcServer& server
+			       , Boss::Mod::Rpc& rpc
+			       ) {
+	auto asserter = [](Jsmn::Object const& req) {
+		auto id = assert_method(req, "askrene-inform-channel");
+		assert(req.has("params"));
+		auto params = req["params"];
+		assert(params.is_object());
+		assert(params.has("layer"));
+		assert(std::string(params["layer"]) == "test-layer");
+		assert(params.has("short_channel_id_dir"));
+		assert(std::string(params["short_channel_id_dir"]) == "100x1x0/1");
+		assert(params.has("amount_msat"));
+		assert(double(params["amount_msat"]) == 500000.0);
+		assert(params.has("inform"));
+		assert(std::string(params["inform"]) == "constrained");
+		return id;
+	};
+
+	return Ev::lift().then([&server, asserter]() {
+		return Ev::concurrent(server.serve_ok(std::move(asserter)));
+	}).then([&rpc]() {
+		return Boss::Mod::AskreneLayer::inform_channel_constrained(
+			rpc, std::string("test-layer"),
+			Ln::Scid("100x1x0"), std::uint32_t(1),
+			Ln::Amount::msat(500000)
+		);
+	});
+}
+
+/* Test 2: inform_channel_unconstrained sends the same shape but
+ * inform="unconstrained".  This is askrene's mode for "channel
+ * proved capacity >= amount; raise the lower bound."  Askrene
+ * also has an inform="succeeded" mode but that one is currently
+ * a no-op stub upstream, so we use "unconstrained" for the
+ * lower-bound-raise semantic (same as xpay does).
+ */
+Ev::Io<void>
+test_inform_channel_unconstrained( MockRpcServer& server
+				 , Boss::Mod::Rpc& rpc
+				 ) {
+	auto asserter = [](Jsmn::Object const& req) {
+		auto id = assert_method(req, "askrene-inform-channel");
+		auto params = req["params"];
+		assert(std::string(params["short_channel_id_dir"]) == "200x2x0/0");
+		assert(double(params["amount_msat"]) == 750000.0);
+		assert(std::string(params["inform"]) == "unconstrained");
+		return id;
+	};
+
+	return Ev::lift().then([&server, asserter]() {
+		return Ev::concurrent(server.serve_ok(std::move(asserter)));
+	}).then([&rpc]() {
+		return Boss::Mod::AskreneLayer::inform_channel_unconstrained(
+			rpc, std::string("test-layer"),
+			Ln::Scid("200x2x0"), std::uint32_t(0),
+			Ln::Amount::msat(750000)
+		);
+	});
+}
+
+/* Test 3: disable_node sends askrene-disable-node with the right
+ * shape.
+ */
+Ev::Io<void>
+test_disable_node( MockRpcServer& server
+		 , Boss::Mod::Rpc& rpc
+		 ) {
+	auto const node_str = std::string(
+		"020000000000000000000000000000000000000000000000000000000000000000"
+	);
+
+	auto asserter = [node_str](Jsmn::Object const& req) {
+		auto id = assert_method(req, "askrene-disable-node");
+		auto params = req["params"];
+		assert(std::string(params["layer"]) == "test-layer");
+		assert(params.has("node"));
+		assert(std::string(params["node"]) == node_str);
+		return id;
+	};
+
+	return Ev::lift().then([&server, asserter]() {
+		return Ev::concurrent(server.serve_ok(std::move(asserter)));
+	}).then([&rpc, node_str]() {
+		return Boss::Mod::AskreneLayer::disable_node(
+			rpc, std::string("test-layer"),
+			Ln::NodeId(node_str)
+		);
+	});
+}
+
+/* Test 4: helper silently swallows RpcError -- if the layer is
+ * missing (e.g. CLN without askrene), the helper's Ev::Io<void>
+ * should still complete cleanly rather than propagating the
+ * exception.  Verify by having the mock reply with an RPC error
+ * and confirming the helper still completes (we reach the next
+ * .then in main).
+ */
+Ev::Io<void>
+test_silent_rpc_error( MockRpcServer& server
+		     , Boss::Mod::Rpc& rpc
+		     ) {
+	auto asserter = [](Jsmn::Object const& req) {
+		return assert_method(req, "askrene-inform-channel");
+	};
+
+	return Ev::lift().then([&server, asserter]() {
+		return Ev::concurrent(server.serve_error(std::move(asserter)));
+	}).then([&rpc]() {
+		return Boss::Mod::AskreneLayer::inform_channel_constrained(
+			rpc, std::string("test-layer"),
+			Ln::Scid("300x3x0"), std::uint32_t(0),
+			Ln::Amount::msat(100)
+		);
+	});
+}
+
+} // namespace
+
+int main() {
+	auto bus = S::Bus();
+
+	int sockets[2];
+	auto sockres = socketpair(AF_UNIX, SOCK_STREAM, 0, sockets);
+	assert(sockres >= 0);
+	auto server_socket = Net::Fd(sockets[0]);
+	auto client_socket = Net::Fd(sockets[1]);
+
+	auto server = MockRpcServer(std::move(server_socket));
+	auto rpc = Boss::Mod::Rpc(bus, std::move(client_socket));
+
+	auto code = Ev::lift().then([&]() {
+		return test_inform_channel_constrained(server, rpc);
+	}).then([&]() {
+		return test_inform_channel_unconstrained(server, rpc);
+	}).then([&]() {
+		return test_disable_node(server, rpc);
+	}).then([&]() {
+		return test_silent_rpc_error(server, rpc);
+	}).then([&]() {
+		/* All tests passed; raise Shutdown so concurrent
+		 * server tasks (if any are still alive) and the
+		 * event loop exit cleanly.
+		 */
+		return bus.raise(Boss::Shutdown{});
+	}).then([]() {
+		return Ev::lift(0);
+	});
+
+	auto ec = Ev::start(code);
+	assert(ec == 0);
+	return 0;
+}


### PR DESCRIPTION
PR2 (#315) introduced a persistent askrene layer named "clboss"
to hold accumulated failure-feedback that future getroutes calls
automatically route around.  But the only writer to that layer
in PR2 is FundsMover/Attempter, which rarely fires real sendpay
attempts in practice -- on signet specifically, FundsMover's
prorated-fee-budget check gates out almost every attempt before
sendpay runs, so the layer in production stays empty.  The
architectural promise of "shared failure-feedback knowledge across
all CLBOSS subsystems" never materialises.

ActiveProber, by contrast, fires real sendpay probes against our
peers on a stochastic ~10-minute timer.  Each probe is a 2-hop
payment (us -> peer -> some neighbour of peer) with a bit-flipped
random payment_hash, designed to fail at the final hop with
WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS as the "success"
outcome.  This PR turns each probe outcome into one entry in the
clboss layer, making it the dominant feeder and finally giving
the layer real content.

* Probe outcome discrimination

For each probe (route = [chan0=us->peer, chan1=peer->id1]):

  failcode 0x400F (WIRE_INCORRECT_OR_UNKNOWN_PAYMENT_DETAILS) at
  the destination -> probe success -> askrene-inform-channel
  inform=succeeded chan1 amount1 (raises a lower-bound estimate
  on the channel's capacity).

  CHANNEL-level failure on chan1 -> askrene-inform-channel
  inform=constrained chan1 amount1 (upper-bound constraint).

  NODE-level failure (failcode bit 0x2000) -> askrene-disable-node
  on the erring node.

  Unparseable onion (code 202) -> askrene-disable-node on id1
  (best-guess culprit on a 2-hop route).

  echan == chan0 (our own outbound channel had the issue) -> skip.
  CLBOSS already has authoritative knowledge of local channel
  state from listpeerchannels; no need to re-record in the
  shared layer.

Because probe-success is the common outcome in healthy networks,
the success-feed becomes the dominant signal source -- not the
failure feed.  Over time the layer accumulates a steady stream
of "this channel pushed amount X recently" observations that
askrene treats as lower-bound capacity raises.

* Commits

  1. AskreneLayer: extract shared helpers for clboss layer writes.
     Pure refactor.  Moves the inform_channel / disable_node
     helpers and the "clboss" layer-name constant from
     Boss::Mod::FundsMover::Attempter (private members) into a
     new shared module Boss::Mod::AskreneLayer (free functions).
     FundsMover keeps calling the same logic, just via the new
     module.

  2. ActiveProber: feed sendpay failures into the clboss askrene
     layer.  Wires the catching<RpcError> on ActiveProber's
     waitsendpay to parse erring_index / erring_channel /
     erring_direction / erring_node / failcode out of the error
     data, discriminate per the table above, and call into
     AskreneLayer.

  3. ActiveProber: feed inform=succeeded on probe success.
     Symmetric positive feed -- when the probe's expected final-
     hop reject arrives, record the proven lower-bound capacity
     on chan1.

  4. tests/boss/test_askrene_layer: unit tests for the shared
     helpers.  Four mocked-RPC tests covering
     inform_channel_constrained, inform_channel_succeeded,
     disable_node, and the silent-RpcError-swallow contract
     (any layer-write call gracefully degrades to no-op if the
     RPC fails -- e.g. older CLN where askrene layers do not
     exist).


* Stack

Stacked on #316 (PR3, xpay migration).  Merge order:
#314 (PR1, getroutes) -> #315 (PR2, FundsMover layer) ->
#316 (PR3, xpay) -> this PR.

PR2's layer-write code paths (askrene-inform-channel,
askrene-disable-node) remain identical in behaviour after the
refactor in commit 1; the helpers are just hoisted into a
shared spot.  No regressions to FundsMover's existing flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Wires ActiveProber to feed outcome feedback into the persistent "clboss" askrene layer by parsing waitsendpay errors and discriminating between probe successes (failcode 0x400F), channel-level failures, node-level failures (0x2000 bit set), and unparseable onions (code 202), with logic to skip writing for local outgoing channel failures.

- Extracts reusable AskreneLayer helpers (inform_channel_constrained, inform_channel_unconstrained, disable_node) and the clboss_layer_name constant into a new Boss::Mod::AskreneLayer module, with all helpers gracefully swallowing RpcErrors to degrade to no-op on older CLN versions.

- Refactors FundsMover/Attempter to use the centralized AskreneLayer helpers instead of local implementations (no behavioral change) and adds unit tests covering the new helpers' RPC request shapes and silent-error-swallow contract.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ksedgwic/clboss/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->