### PR TITLE
cln-v26.06-compat: FundsMover: clboss askrene layer maintenance — 24h aging, self-exclude, positive reinforcement

### DIFF
--- a/Boss/Mod/AskreneLayer.cpp
+++ b/Boss/Mod/AskreneLayer.cpp
@@ -4,6 +4,7 @@
 #include"Jsmn/Object.hpp"
 #include"Json/Out.hpp"
 #include"Util/stringify.hpp"
+#include"Uuid.hpp"
 #include<assert.h>
 
 namespace Boss { namespace Mod { namespace AskreneLayer {
@@ -95,6 +96,60 @@ disable_node( Boss::Mod::Rpc& rpc
 		.end_object()
 		;
 	return rpc.command( "askrene-disable-node"
+			  , std::move(parms)
+			  ).then([](Jsmn::Object _) {
+		return Ev::lift();
+	}).catching<RpcError>([](RpcError const&) {
+		return Ev::lift();
+	});
+}
+
+Ev::Io<std::string>
+create_transient_layer(Boss::Mod::Rpc& rpc) {
+	auto name = std::string("clboss-attempt-")
+		  + std::string(Uuid::random());
+	auto parms = Json::Out()
+		.start_object()
+			.field("layer", name)
+			.field("persistent", false)
+		.end_object()
+		;
+	return rpc.command( "askrene-create-layer"
+			  , std::move(parms)
+			  ).then([name](Jsmn::Object _) {
+		return Ev::lift(name);
+	}).catching<RpcError>([](RpcError const&) {
+		/* On failure (e.g. CLN < v24.11 where askrene-create-
+		 * layer does not exist), return empty so the caller
+		 * can detect we have no transient layer and degrade
+		 * gracefully -- crucially, NOT pass the would-be-name
+		 * to subsequent getroutes calls, since askrene's
+		 * param_layer_names validator (askrene.c) fails the
+		 * whole getroutes call with "unknown layer" if any
+		 * name in the layers array does not exist.
+		 */
+		return Ev::lift(std::string(""));
+	});
+}
+
+Ev::Io<void>
+remove_layer( Boss::Mod::Rpc& rpc
+	    , std::string const& layer
+	    ) {
+	/* Skip the RPC roundtrip if the layer name is empty (the
+	 * convention create_transient_layer uses on creation
+	 * failure).  askrene-remove-layer with an empty name would
+	 * error and we would swallow it, but the round-trip is
+	 * wasted.
+	 */
+	if (layer.empty())
+		return Ev::lift();
+	auto parms = Json::Out()
+		.start_object()
+			.field("layer", layer)
+		.end_object()
+		;
+	return rpc.command( "askrene-remove-layer"
 			  , std::move(parms)
 			  ).then([](Jsmn::Object _) {
 		return Ev::lift();

--- a/Boss/Mod/AskreneLayer.hpp
+++ b/Boss/Mod/AskreneLayer.hpp
@@ -69,6 +69,50 @@ Ev::Io<void> disable_node( Boss::Mod::Rpc& rpc
 			 , Ln::NodeId node
 			 );
 
+/* Create a fresh non-persistent askrene layer scoped to a single
+ * caller (typically one FundsMover::Attempter run).  The layer's
+ * lifetime is the caller's responsibility -- pair with remove_layer
+ * at the end of the run.  Used to encode absolute within-run
+ * exclusions (e.g. failing channel-directions) that should NOT
+ * accumulate in the persistent clboss layer because:
+ *
+ *   - The failcode might not be a capacity issue (FEE_INSUFFICIENT,
+ *     CLTV problems, etc.) -- persistent max_msat would be the
+ *     wrong feedback and accumulate misinformation.
+ *   - Even when the failcode IS capacity-related, conditional
+ *     max_msat constraints in the persistent layer can be re-
+ *     selected at amount = max_msat - 1, producing a ratchet-
+ *     by-1-msat retry storm if askrene's gossmap hasn't refreshed
+ *     between failure and retry.  An absolute "channel disabled"
+ *     write in a transient layer dominates the conditional
+ *     max_msat (askrene takes the min of all max_msats across
+ *     layers, askrene/layer.c:1004-1009) and ends the storm.
+ *
+ * Layer name is "clboss-attempt-<uuid>" where uuid is a fresh
+ * 16-byte random value (Uuid::random()).  Returned name should be
+ * passed to subsequent inform_channel_constrained / disable_node
+ * calls (with this layer name instead of clboss_layer_name) and
+ * to remove_layer at the end.
+ *
+ * Non-fatal on RpcError: returns the would-be layer name even on
+ * failure so the caller can still attempt remove_layer (a no-op
+ * if create failed), and subsequent inform/disable writes will
+ * also fail silently in degraded-learning mode -- the
+ * within-attempter retry storm protection is lost but the
+ * Attempter itself continues to work.
+ */
+Ev::Io<std::string> create_transient_layer(Boss::Mod::Rpc& rpc);
+
+/* Remove the named layer.  Used to clean up a transient layer
+ * created by create_transient_layer at the end of the caller's
+ * lifetime.  Non-fatal on RpcError: a leaked transient layer is
+ * bounded (persistent=false means it does not survive plugin
+ * restart) but should be rare in practice.
+ */
+Ev::Io<void> remove_layer( Boss::Mod::Rpc& rpc
+			 , std::string const& layer
+			 );
+
 }}}
 
 #endif /* !defined(BOSS_MOD_ASKRENELAYER_HPP_) */

--- a/Boss/Mod/FundsMover/Attempter.cpp
+++ b/Boss/Mod/FundsMover/Attempter.cpp
@@ -64,6 +64,19 @@ private:
 	/* The fee we currently have.  */
 	Ln::Amount our_fee;
 
+	/* Non-persistent askrene layer scoped to this single Attempter
+	 * run.  Created at the start of core_run(), used to record
+	 * absolute within-run exclusions for failing channel-directions
+	 * (independent of the persistent clboss layer's conditional
+	 * max_msat constraints), removed at the end of run().  See
+	 * AskreneLayer::create_transient_layer for the rationale.
+	 *
+	 * Empty until create_transient_layer resolves; remove_layer is
+	 * still safe to call on an empty name (the underlying helper
+	 * swallows RpcError).
+	 */
+	std::string transient_layer_name;
+
 public:
 	Impl( S::Bus& bus_
 	    , Boss::Mod::Rpc& rpc_
@@ -100,6 +113,18 @@ public:
 	Ev::Io<bool> run() {
 		auto self = shared_from_this();
 		return self->core_run().then([self]() {
+			/* Tear down the transient layer (if created)
+			 * before returning.  Fire-and-forget: the helper
+			 * swallows RpcError, and a leaked layer is bounded
+			 * (persistent=false means it does not survive
+			 * plugin restart).  Done as a then-chain rather
+			 * than a destructor because the cleanup requires
+			 * an async RPC call.
+			 */
+			return Boss::Mod::AskreneLayer::remove_layer(
+				self->rpc, self->transient_layer_name
+			);
+		}).then([self]() {
 			return Ev::lift(self->ok);
 		});
 	}
@@ -107,6 +132,17 @@ public:
 private:
 	Ev::Io<void> core_run() {
 		return Ev::lift().then([this]() {
+			/* Stand up the per-Attempter transient askrene
+			 * layer that records absolute within-run hop
+			 * exclusions.  See the layer's role in getroute()
+			 * and in the sendpay failure handler below.
+			 */
+			return Boss::Mod::AskreneLayer::create_transient_layer(
+				rpc
+			);
+		}).then([this](std::string name) {
+			transient_layer_name = std::move(name);
+
 			/* dest_amount is the amount destination should
 			 * receive on its incoming channel from us.  Old
 			 * comment is preserved because the math is the
@@ -150,26 +186,33 @@ private:
 					  ? prorated_fee_budget - dest_hop_fee
 					  : Ln::Amount::sat(0);
 
-			auto parms = Json::Out()
-				.start_object()
-					.field("source", std::string(source))
-					.field("destination",
-					       std::string(destination))
-					.field("amount_msat",
-					       dest_amount.to_msat())
-					.start_array("layers")
-						.entry("auto.localchans")
-						.entry("auto.sourcefree")
-						.entry(Boss::Mod::AskreneLayer::clboss_layer_name)
-					.end_array()
-					.field("maxfee_msat",
-					       route_maxfee.to_msat())
-					.field("final_cltv",
-					       cltv_delta + 14)
-					.field("maxparts", 1)
-				.end_object()
-				;
-			return rpc.command("getroutes", std::move(parms));
+			auto pj = Json::Out();
+			auto obj = pj.start_object();
+			obj.field("source", std::string(source));
+			obj.field("destination", std::string(destination));
+			obj.field("amount_msat", dest_amount.to_msat());
+			auto la = obj.start_array("layers");
+			la.entry("auto.localchans");
+			la.entry("auto.sourcefree");
+			la.entry(Boss::Mod::AskreneLayer::clboss_layer_name);
+			/* Within-Attempter absolute exclusions live in
+			 * the transient layer; dominates the persistent
+			 * clboss layer's conditional max_msat constraints
+			 * (askrene takes min across layers).  Empty name
+			 * means create_transient_layer failed at the
+			 * start of core_run() -- skip the entry rather
+			 * than pass a nonexistent name to askrene's
+			 * param_layer_names validator (which would fail
+			 * the whole getroutes call with "unknown layer").
+			 */
+			if (!transient_layer_name.empty())
+				la.entry(transient_layer_name);
+			la.end_array();
+			obj.field("maxfee_msat", route_maxfee.to_msat());
+			obj.field("final_cltv", cltv_delta + 14);
+			obj.field("maxparts", 1);
+			obj.end_object();
+			return rpc.command("getroutes", std::move(pj));
 		}).then([this](Jsmn::Object res) {
 			try {
 				auto routes = res["routes"];
@@ -586,28 +629,95 @@ private:
 							)
 					     ;
 				/* 0x2000 == NODE level error.  */
-				if ((fail & 0x2000))
+				if ((fail & 0x2000)) {
+					/* Persistent disable_node is correct
+					 * for NODE-level failures and is also
+					 * consulted by this Attempter's own
+					 * subsequent getroutes calls (the
+					 * clboss layer is in the layers
+					 * array), so no separate transient
+					 * write is needed for this case.
+					 */
 					feedback = Boss::Mod::AskreneLayer::disable_node(
 						rpc,
 						Boss::Mod::AskreneLayer::clboss_layer_name,
 						enode
 					);
-				else
-					/* The amount to pass to askrene-inform-channel
-					 * is the HTLC amount attempted on the specific
-					 * failing channel, not the downstream destination
-					 * amount.  eidx indexes [hop0, route..., hoplast];
-					 * we have already returned early for eidx == 0
-					 * and eidx == route.size() + 1, so eidx is in
-					 * [1, route.size()] here and route[eidx - 1]
-					 * describes the failing channel.
+				} else {
+					/* Record an absolute within-Attempter
+					 * exclusion in the transient layer
+					 * (when available; degraded mode if
+					 * create_transient_layer failed).
+					 * amount_msat=1 to inform=constrained
+					 * writes max_msat=0, which dominates
+					 * any persistent layer conditional and
+					 * prevents askrene from re-selecting
+					 * this channel-direction at amount-1
+					 * (the ratchet-by-1-msat retry storm).
+					 *
+					 * eidx indexes [hop0, route...,
+					 * hoplast]; we have already returned
+					 * early for eidx == 0 and eidx ==
+					 * route.size() + 1, so eidx is in
+					 * [1, route.size()] here and
+					 * route[eidx - 1] describes the
+					 * failing channel.
 					 */
-					feedback = Boss::Mod::AskreneLayer::inform_channel_constrained(
-						rpc,
-						Boss::Mod::AskreneLayer::clboss_layer_name,
-						echan, edir,
-						route[eidx - 1].amount_msat
-					);
+					if (!transient_layer_name.empty())
+						feedback = Boss::Mod::AskreneLayer::inform_channel_constrained(
+							rpc,
+							transient_layer_name,
+							echan, edir,
+							Ln::Amount::msat(1)
+						);
+					/* For genuine capacity failures
+					 * (0x1007 WIRE_TEMPORARY_CHANNEL_
+					 * FAILURE) only, additionally
+					 * record a conditional max_msat
+					 * constraint in the persistent
+					 * clboss layer.  This is the only
+					 * non-NODE failcode where capacity-
+					 * shaped feedback is semantically
+					 * correct: the channel really cannot
+					 * carry this amount right now, and
+					 * the constraint is useful across
+					 * subsequent Attempters (and other
+					 * CLBOSS subsystems consuming the
+					 * layer) for at least the few
+					 * minutes until liquidity shifts
+					 * again.
+					 *
+					 * For other non-NODE failcodes
+					 * (0x100c WIRE_FEE_INSUFFICIENT,
+					 * 0x100b WIRE_AMOUNT_BELOW_MINIMUM,
+					 * 0x100d WIRE_INCORRECT_CLTV_EXPIRY,
+					 * 0x100e WIRE_EXPIRY_TOO_SOON, etc.)
+					 * skip the persistent write.  Those
+					 * failures are HTLC-parameter
+					 * problems, not capacity problems;
+					 * writing max_msat for them would
+					 * store misinformation that
+					 * pollutes future getroutes calls
+					 * until the entry ages out.  The
+					 * transient exclusion above is
+					 * sufficient to prevent re-selection
+					 * within this Attempter, and CLN's
+					 * normal gossip update from the
+					 * channel_update embedded in those
+					 * errors will refresh the actual
+					 * fee/CLTV/min state for future
+					 * attempts.
+					 */
+					if (fail == 0x1007) {
+						feedback = std::move(feedback)
+							 + Boss::Mod::AskreneLayer::inform_channel_constrained(
+								rpc,
+								Boss::Mod::AskreneLayer::clboss_layer_name,
+								echan, edir,
+								route[eidx - 1].amount_msat
+							);
+					}
+				}
 			} else {
 				/* Unparsable onion (code 202): we cannot pin
 				 * the failure to a specific channel.  The

--- a/Boss/Mod/FundsMover/Attempter.cpp
+++ b/Boss/Mod/FundsMover/Attempter.cpp
@@ -413,7 +413,42 @@ private:
 		}).then([this, payment_hash](Jsmn::Object _) {
 			/* Success?  Now we can stop.  */
 			ok = true;
+
+			/* Positive reinforcement: every middle hop in
+			 * this route just proved it can carry at least
+			 * the amount it actually carried.  Record those
+			 * lower-bound observations into the persistent
+			 * clboss askrene layer so future getroutes calls
+			 * see a balanced picture, not a monotonically
+			 * darkening one of only failure-driven upper
+			 * bounds.  Per-hop amount_msat is what that
+			 * specific channel carried (the amount shrinks
+			 * hop by hop as fees are subtracted along the
+			 * route).
+			 *
+			 * Us->source and destination->us hops are
+			 * skipped on the same rationale ActiveProber
+			 * applies to its chan0: local channel state is
+			 * already authoritative via listpeerchannels /
+			 * auto.localchans, so the shared askrene layer
+			 * is reserved for cross-subsystem knowledge.
+			 *
+			 * PR5's askrene-age sweep ages these entries on
+			 * the same 24h cadence as the failure entries.
+			 */
+			auto reinforcement = Ev::lift();
+			for (auto const& hop : route) {
+				reinforcement = std::move(reinforcement)
+					      + Boss::Mod::AskreneLayer::inform_channel_unconstrained(
+							rpc,
+							Boss::Mod::AskreneLayer::clboss_layer_name,
+							hop.scid, hop.direction,
+							hop.amount_msat
+						);
+			}
+
 			return delpay(payment_hash, true)
+			     + std::move(reinforcement)
 			     + Boss::log( bus, Info
 					, "FundsMover: Moved %s from %s, "
 					  "getting %s to %s, costing us "
@@ -423,6 +458,13 @@ private:
 					, std::string(amount).c_str()
 					, std::string(destination).c_str()
 					, std::string(our_fee).c_str()
+					)
+			     + Boss::log( bus, Debug
+					, "FundsMover: positive "
+					  "reinforcement: wrote min_msat "
+					  "for %zu middle hop(s) to clboss "
+					  "layer."
+					, route.size()
 					)
 			     ;
 		}).catching<RpcError>([ this

--- a/Boss/Mod/FundsMover/Main.cpp
+++ b/Boss/Mod/FundsMover/Main.cpp
@@ -9,6 +9,7 @@
 #include"Boss/Msg/ProvideDeletablePaymentLabelFilter.hpp"
 #include"Boss/Msg/RequestMoveFunds.hpp"
 #include"Boss/Msg/SolicitDeletablePaymentLabelFilter.hpp"
+#include"Boss/Msg/TimerRandomHourly.hpp"
 #include"Boss/concurrent.hpp"
 #include"Boss/log.hpp"
 #include"Ev/Io.hpp"
@@ -19,6 +20,8 @@
 #include"S/Bus.hpp"
 #include"Util/make_unique.hpp"
 #include"Util/stringify.hpp"
+#include<cinttypes>
+#include<ctime>
 
 #if HAVE_CONFIG_H
 # include"config.h"
@@ -103,6 +106,12 @@ private:
 					&is_our_label
 			});
 		});
+		bus.subscribe<Msg::TimerRandomHourly
+			     >([this](Msg::TimerRandomHourly const& _) {
+			return wait_for_ready().then([this]() {
+				return age_clboss_layer();
+			});
+		});
 	}
 	/* Gate Msg::RequestMoveFunds handling on FundsMover's
 	 * startup-time setup: rpc must have arrived via Msg::Init,
@@ -119,6 +128,93 @@ private:
 			if (!rpc || !layer_ready)
 				return Ev::yield() + wait_for_ready();
 			return Ev::lift();
+		});
+	}
+
+	/* Trim clboss-layer entries older than aging_window_secs.
+	 * Without this, askrene-inform-channel constraints (and any
+	 * disable_node writes) recorded over the lifetime of CLBOSS
+	 * would persist forever -- askrene does NOT consult the
+	 * per-entry timestamp during route scoring; the timestamp
+	 * is only used by this explicit aging RPC to delete entries
+	 * with timestamp < cutoff.
+	 *
+	 * Without aging, transient capacity dips and one-off node
+	 * outages would embed permanently in CLBOSS's routing model.
+	 *
+	 * Cadence is driven by Msg::TimerRandomHourly (~once per
+	 * hour with jitter) and the 24h window is chosen to roughly
+	 * match the ActiveProber natural-refresh cadence (each peer
+	 * is probed once every ~24h on average -- see
+	 * RegularActiveProbe's uniform(1, 144) per 10 min dice
+	 * roll); the explicit aging is the only freshness mechanism
+	 * for FundsMover-written constraints (since FundsMover
+	 * routes around them and never re-tests).
+	 *
+	 * Compared to xpay's own layer (cutoff 1h, fires every
+	 * 60s) we are much less aggressive because CLBOSS's
+	 * rebalance and probe cadence is on a 24h+ timescale.
+	 *
+	 * RpcError swallowed for graceful degradation, same pattern
+	 * as create_clboss_layer.
+	 */
+	Ev::Io<void> age_clboss_layer() {
+		auto constexpr aging_window_secs = std::uint64_t(86400);
+		return Ev::lift().then([this]() {
+			auto cutoff = std::uint64_t(std::time(nullptr))
+				    - aging_window_secs;
+			auto parms = Json::Out()
+				.start_object()
+					.field("layer",
+					       Boss::Mod::AskreneLayer::clboss_layer_name)
+					.field("cutoff", cutoff)
+				.end_object()
+				;
+			return rpc->command( "askrene-age"
+					   , std::move(parms)
+					   );
+		}).then([this](Jsmn::Object res) {
+			auto removed = std::uint64_t(0);
+			if (res.has("num_removed")
+			 && res["num_removed"].is_number())
+				removed = std::uint64_t(double(res["num_removed"]));
+			return Boss::log( bus, Debug
+					, "FundsMover: askrene-age (clboss) "
+					  "removed %" PRIu64 " stale entries."
+					, removed
+					);
+		}).catching<RpcError>([this](RpcError const& e) {
+			/* Distinguish CLN-too-old (askrene-age RPC
+			 * missing) from other failures.  The standard
+			 * JSON-RPC "method not found" code (-32601) is
+			 * the explicit graceful-degradation case
+			 * (CLN < v24.11, no askrene plugin); we keep
+			 * that at Debug so older nodes don't spam logs
+			 * once an hour.  Any other RpcError suggests
+			 * something unexpected (transient askrene
+			 * problem, layer corruption, etc.) -- promote
+			 * to Warn since this aging path is the only
+			 * cleanup for FundsMover-written constraints,
+			 * and a sustained failure would let stale
+			 * pessimism accumulate indefinitely.
+			 */
+			auto code = int(0);
+			if (e.error.has("code") && e.error["code"].is_number())
+				code = int(double(e.error["code"]));
+			auto is_method_missing = (code == -32601);
+			return Boss::log( bus
+					, is_method_missing ? Debug : Warn
+					, "FundsMover: askrene-age (clboss) "
+					  "failed: %s%s"
+					, Util::stringify(e.error).c_str()
+					, is_method_missing
+						? " (RPC missing; aging "
+						  "unavailable on this CLN)."
+						: " (unexpected; stale "
+						  "entries will accumulate "
+						  "until next successful "
+						  "aging pass)."
+					);
 		});
 	}
 
@@ -143,6 +239,34 @@ private:
 					   , std::move(parms)
 					   );
 		}).then([this](Jsmn::Object _) {
+			/* Self-exclude from middle hops by adding our
+			 * node_id to the clboss layer's disabled_nodes.
+			 * Without this, askrene-getroutes can return
+			 * paths that loop through us as a middle node
+			 * (us -> source -> us -> destination -> us),
+			 * which appear to succeed but actually drain
+			 * the destination channel in the wrong direction
+			 * while paying fees for zero net progress.
+			 *
+			 * The legacy getroute call had this protection
+			 * via its exclude=[self_id] argument; the
+			 * askrene-getroutes API has no inline equivalent,
+			 * so the persistent layer's disabled_nodes set
+			 * is the only path to express the same intent.
+			 *
+			 * Idempotency: layer_add_disabled_node appends
+			 * without de-dup so successive restarts will
+			 * accumulate duplicate self entries, but the
+			 * layer_disables_node membership check works
+			 * correctly with duplicates -- minor storage
+			 * bloat we accept as cheap.
+			 */
+			return Boss::Mod::AskreneLayer::disable_node(
+				*rpc,
+				Boss::Mod::AskreneLayer::clboss_layer_name,
+				self_id
+			);
+		}).then([this]() {
 			layer_ready = true;
 			return Ev::lift();
 		}).catching<RpcError>([this](RpcError const& e) {


### PR DESCRIPTION
  This PR bundles three small improvements to how FundsMover
  uses the persistent clboss askrene layer, all originally
  motivated by the PR1-5 migration to askrene-getroutes:

    1. (commit 1) FundsMover periodically calls askrene-age
       on the clboss layer with a 24h cutoff, so stale
       capacity constraints do not embed permanently into
       CLBOSS's routing model.

    2. (commit 1) FundsMover adds its own node_id to the
       clboss layer's disabled_nodes set at startup, so
       askrene-getroutes cannot return rebalance routes that
       loop back through us as a middle hop.  This restores
       the protection that the legacy getroute call provided
       via its exclude=[self_id] argument.

    3. (commit 2) FundsMover writes positive reinforcement
       (askrene-inform-channel inform=unconstrained) for each
       middle hop of a successful rebalance.  This balances
       the layer against PR2's failure-feedback writes, which
       are otherwise monotonically pessimistic.

  Together these three make the clboss layer self-correcting
  rather than monotonically darkening.  Each has direct
  observability via askrene-listlayers clboss and a new or
  existing FundsMover Debug log line.
