### PR TITLE
Signet support for the Boltz swapper

### DIFF
--- a/Boss/Mod/BoltzSwapper/Main.cpp
+++ b/Boss/Mod/BoltzSwapper/Main.cpp
@@ -5,59 +5,67 @@
 
 namespace {
 
-auto const boltz_instances = std::map< Boss::Msg::Network
-				     , std::vector<Boss::Mod::BoltzSwapper::Instance>
-				     >
-{ { Boss::Msg::Network_Bitcoin
-/* Historically, the clearnet API endpoint was used as the in-database label
- * for Boltz services.
- * The boltz.exchange service thus uses the API endpoint as the label for
- * back-compatibility.
- * Other services since then were added after we had a separate label.
- */
-  , { { "https://boltz.exchange/api"
-      , "https://boltz.exchange/api"
-      , "http://boltzzzbnus4m7mta3cxmflnps4fp7dueu2tgurstbvrbt6xswzcocyd.onion/api"
+    auto const boltz_instances = std::map< Boss::Msg::Network, std::vector<Boss::Mod::BoltzSwapper::Instance> >
+    {
+        { Boss::Msg::Network_Bitcoin,
+    /* Historically, the clearnet API endpoint was used as the in-database label
+     * for Boltz services.
+     * The boltz.exchange service thus uses the API endpoint as the label for
+     * back-compatibility.
+     * Other services since then were added after we had a separate label.
+     */
+      {
+          { "https://boltz.exchange/api",
+          "https://boltz.exchange/api",
+          "http://boltzzzbnus4m7mta3cxmflnps4fp7dueu2tgurstbvrbt6xswzcocyd.onion/api"
+          },
+          { "AutonomousOrganization@github.com",
+              "",
+              "http://jsyqqszgfrya6nj7nhi4hu4tdpuvfursl7dyxeiukzit5mvckqbzxpad.onion"
+            }
       }
-    , { "AutonomousOrganization@github.com"
-      , ""
-      , "http://jsyqqszgfrya6nj7nhi4hu4tdpuvfursl7dyxeiukzit5mvckqbzxpad.onion"
-      }
-    }
-  }
-, { Boss::Msg::Network_Testnet
-  , { { "https://testnet.boltz.exchange/api"
-      , "https://testnet.boltz.exchange/api"
-      , "http://tboltzzrsoc3npe6sydcrh37mtnfhnbrilqi45nao6cgc6dr7n2eo3id.onion/api"
-      }
-    }
-  }
-};
+    },
+        { Boss::Msg::Network_Signet,
+            {
+              { "signet-boltz-backend-for-clboss",
+                  "http://127.0.0.1:8080",
+                  "http://boltz7ckqss7j66wjjqlm334qccsrjie552gdnvn6vwztnzk7bqwsdad.onion"
+              }
+          }
+        },
+        { Boss::Msg::Network_Testnet,
+            {
+              { "https://testnet.boltz.exchange/api",
+                  "https://testnet.boltz.exchange/api",
+                  "http://tboltzzrsoc3npe6sydcrh37mtnfhnbrilqi45nao6cgc6dr7n2eo3id.onion/api"
+              }
+          }
+        }
+    };
 
 }
 
 namespace Boss { namespace Mod { namespace BoltzSwapper {
 
-class Main::Impl {
-private:
-	Env env;
-	ServiceCreator creator;
+    class Main::Impl {
+    private:
+        Env env;
+        ServiceCreator creator;
 
-public:
-	Impl(S::Bus& bus, Ev::ThreadPool& threadpool)
-		: env(bus)
-		, creator(bus, threadpool, env, boltz_instances)
-		{ }
-};
+    public:
+        Impl(S::Bus& bus, Ev::ThreadPool& threadpool)
+            : env(bus)
+            , creator(bus, threadpool, env, boltz_instances)
+        { }
+    };
 
-Main::Main(Main&&) =default;
-Main& Main::operator=(Main&&) =default;
-Main::~Main() =default;
+    Main::Main(Main&&) =default;
+    Main& Main::operator=(Main&&) =default;
+    Main::~Main() =default;
 
-Main::Main( S::Bus& bus
-	  , Ev::ThreadPool& threadpool
-	  ) : pimpl(Util::make_unique<Impl>(bus, threadpool))
-	    { }
+    Main::Main( S::Bus& bus
+          , Ev::ThreadPool& threadpool
+          ) : pimpl(Util::make_unique<Impl>(bus, threadpool))
+    { }
 
 }}}
-

--- a/README.md
+++ b/README.md
@@ -228,6 +228,53 @@ Installing `lcov`:
 * Debian/Ubuntu: `sudo apt-get install lcov`
 * Or via Nix (without installing system-wide): `nix shell nixpkgs#lcov --command make coverage-report`
 
+### Testing on signet w/ swaps
+
+CLBOSS can run its `boltz.exchange` swaps against a signet Boltz backend,
+which is useful for exercising the swap machinery without spending real
+funds. This needs a CLBOSS built with signet support, which ships a
+`Network_Signet` Boltz instance.
+
+The signet Boltz service has no public clearnet endpoint, so CLBOSS
+reaches it at a local address (`http://127.0.0.1:8080`) that you front
+with a forward to the service. The service is reachable over I2P
+(preferred) or Tor — its `.onion` is also configured, but has been
+unreliable in practice.
+
+To forward the local port over I2P:
+
+1. Install and run [i2pd](https://i2pd.readthedocs.io/). Its SOCKS5 proxy
+   listens on `127.0.0.1:4447` by default; no extra configuration is
+   required.
+
+2. Forward `127.0.0.1:8080` to the signet Boltz I2P address through that
+   SOCKS5 proxy with `socat`. A systemd unit keeps it running:
+
+```
+[Unit]
+Description=socat proxy: 127.0.0.1:8080 -> Boltz signet I2P (via i2pd SOCKS5)
+After=i2pd.service network-online.target
+Wants=i2pd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/socat --experimental -d TCP4-LISTEN:8080,bind=127.0.0.1,fork,reuseaddr SOCKS5-CONNECT:127.0.0.1:4447:boltz7c3f7bb5pe7k25uv2wdd57oayoazacorwdvzksz6q7hicxq.b32.i2p:80
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+For a one-off test, run just the `socat …` command from `ExecStart`
+directly. With i2pd and this forward running, a signet CLBOSS uses the
+Boltz signet backend automatically.
+
+To smoke-test the backend without CLBOSS, the `dev-boltz-api` helper
+honors two environment variables: set `BOLTZ_PROXY=socks5h://127.0.0.1:4447`
+and `BOLTZ_API_BASE=http://boltz7c3f7bb5pe7k25uv2wdd57oayoazacorwdvzksz6q7hicxq.b32.i2p`
+to reach the service directly over I2P.
+
 ### Contributed Utilities
 
 There are a number of contributed utilities in the `contrib` directory.  See

--- a/dev-boltz-api.cpp
+++ b/dev-boltz-api.cpp
@@ -5,12 +5,17 @@
 #include"Jsmn/Object.hpp"
 #include"Json/Out.hpp"
 #include"Util/make_unique.hpp"
+#include<cstdlib>
 #include<iostream>
 #include<sstream>
 #include<string>
 
 /* argv[1] == /api
  * argv[2] == JSON
+ *
+ * Environment overrides:
+ *   BOLTZ_API_BASE  URL prefix (default: https://boltz.exchange/api)
+ *   BOLTZ_PROXY     libcurl proxy (e.g. socks5h://127.0.0.1:9050)
  */
 int main(int argc, char** argv) {
 	if (argc < 2 || argc > 3) {
@@ -31,8 +36,13 @@ int main(int argc, char** argv) {
 		);
 	}
 
+	auto base = std::string("https://boltz.exchange/api");
+	if (auto e = std::getenv("BOLTZ_API_BASE")) base = e;
+	auto proxy = std::string("");
+	if (auto e = std::getenv("BOLTZ_PROXY")) proxy = e;
+
 	Ev::ThreadPool tp;
-	auto cc = Boltz::Connection(tp);
+	auto cc = Boltz::Connection(tp, base, proxy);
 
 	auto code = Ev::lift().then([&]() {
 		return cc.api(api, std::move(json));


### PR DESCRIPTION
Adds a Boltz backend for the signet network so swap functionality can
be tested on signet. No mainnet behavior change.

- BoltzSwapper instance map gains a signet entry: a localhost clearnet
  endpoint (http://127.0.0.1:8080) plus the service's .onion. There is
  no public signet Boltz clearnet URL, so the operator fronts the
  localhost port with a forward (e.g. socat) to the signet Boltz
  service. Prefer reaching it over I2P (the service's .b32.i2p address
  via i2pd's SOCKS5 proxy); the Tor .onion also works but has been
  unreliable.

- dev-boltz-api: two optional environment variables to exercise the
  signet backend from the CLI without touching mainnet:
    BOLTZ_API_BASE URL prefix (default https://boltz.exchange/api)
    BOLTZ_PROXY libcurl SOCKS5 proxy -- point at i2pd
    (e.g. socks5h://127.0.0.1:4447) for I2P, or Tor
    (socks5h://127.0.0.1:9050) as the flaky fallback With neither set,
    behavior is unchanged (still mainnet Boltz).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added Signet network support to `BoltzSwapper` by introducing a new `Boss::Msg::Network_Signet` entry pointing to the signet Boltz backend, with access designed for swap testing via a localhost HTTP endpoint you forward over I2P (preferred) and/or Tor (`.onion`).  
- Enhanced `dev-boltz-api` with optional `BOLTZ_API_BASE` and `BOLTZ_PROXY` overrides (defaulting to `https://boltz.exchange/api` and no proxy) to support non-mainnet backend smoke tests while preserving mainnet behavior when unset.  
- Updated the root `README` with a “Testing on signet w/ swaps” section describing the `i2pd` SOCKS5 + `socat` port-forward (including a systemd unit example) and direct `dev-boltz-api` I2P-based testing via the new environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->